### PR TITLE
Cast Set to Set, not Seq

### DIFF
--- a/app/com/lynxanalytics/biggraph/graph_operations/Conversions.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/Conversions.scala
@@ -84,7 +84,7 @@ object DynamicValue {
       set =>
         DynamicValue(
           string = set.toSeq.map(e => innerConverter(e).string).sorted.mkString(", "),
-          vector = set.asInstanceOf[Seq[Double]].toList)
+          vector = set.asInstanceOf[Set[Double]].toList)
     } else {
       set => DynamicValue(string = set.toSeq.map(e => innerConverter(e).string).sorted.mkString(", "))
     }


### PR DESCRIPTION
Easy to miss typo! The NUS tutorial manages to trigger this by using a numeric edge attribute as a label. For parallel edges the attributes get added to a Set, and then this happens.