### PR TITLE
Last fixes before release

### DIFF
--- a/app/com/lynxanalytics/biggraph/controllers/OperationParams.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/OperationParams.scala
@@ -25,16 +25,18 @@ object OperationParams {
       options: List[FEOption],
       multipleChoice: Boolean = false,
       allowUnknownOption: Boolean = false,
+      hiddenOptions: List[FEOption] = Nil, // Not offered on the UI, but not an error.
       override val group: String = "") extends OperationParameterMeta {
     val kind = "choice"
     val defaultValue = if (multipleChoice) "" else options.headOption.map(_.id).getOrElse("")
     def validate(value: String): Unit = {
       if (!allowUnknownOption) {
         val possibleValues = options.map { x => x.id }.toSet
+        val hiddenValues = hiddenOptions.map { x => x.id }.toSet
         val givenValues: Set[String] = if (!multipleChoice) Set(value) else {
           if (value.isEmpty) Set() else value.split(",", -1).toSet
         }
-        val unknown = givenValues -- possibleValues
+        val unknown = givenValues -- possibleValues -- hiddenValues
         assert(
           unknown.isEmpty,
           s"Unknown option for $id: ${unknown.mkString(", ")}" +

--- a/app/com/lynxanalytics/biggraph/frontend_operations/EdgeAttributeOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/EdgeAttributeOperations.scala
@@ -75,7 +75,8 @@ class EdgeAttributeOperations(env: SparkFreeEnvironment) extends ProjectOperatio
       project.edgeAttrList[String] ++
         project.edgeAttrList[Long] ++
         project.edgeAttrList[Int]
-    params += Choice("attr", "Edge attribute", options = eligible, multipleChoice = true)
+    params += Choice("attr", "Edge attribute", options = eligible, multipleChoice = true,
+      hiddenOptions = project.edgeAttrList[Double])
     def enabled = project.hasEdgeBundle
     def apply() = {
       for (name <- splitParam("attr")) {

--- a/app/com/lynxanalytics/biggraph/frontend_operations/VertexAttributeOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/VertexAttributeOperations.scala
@@ -90,7 +90,8 @@ class VertexAttributeOperations(env: SparkFreeEnvironment) extends ProjectOperat
       project.vertexAttrList[String] ++
         project.vertexAttrList[Long] ++
         project.vertexAttrList[Int]
-    params += Choice("attr", "Vertex attribute", options = eligible, multipleChoice = true)
+    params += Choice("attr", "Vertex attribute", options = eligible, multipleChoice = true,
+      hiddenOptions = project.vertexAttrList[Double])
     def enabled = project.hasVertexSet
     def apply() = {
       for (name <- splitParam("attr")) {

--- a/web/app/help/directory-ui/directories.asciidoc
+++ b/web/app/help/directory-ui/directories.asciidoc
@@ -5,15 +5,6 @@ group the items is by user: so the workspaces and snaphots of one user would be 
 workspaces and snapshots of another. This organization is encouraged by assigning a private folder to each user
 inside the `Users` folder.
 
-Folders can have access control settings. A list of users who can read or write the folder contents
-can be specified by opening the settings panel
-(+++<label class="btn btn-default"><i class="glyphicon glyphicon-cog"></i></label>+++).
-See the section on <<access-control>> for more details.
-
-Administrator users have access to everything and can fine-tune the access control settings to set
-up any desired system of permissions. This is recommended as part of the LynxKite installation
-procedure.
-
 Click +++<span class="icon glyphicon glyphicon-plus"></span>+++ _New folder_
 to create a new folder inside the current folder.
 

--- a/web/app/help/internals/index.asciidoc
+++ b/web/app/help/internals/index.asciidoc
@@ -2,8 +2,6 @@
 
 include::prefixed-paths.asciidoc[]
 
-include::access-control.asciidoc[]
-
 include::jdbc-details.asciidoc[]
 
 include::sql-syntax.asciidoc[]

--- a/web/app/scripts/report-error.js
+++ b/web/app/scripts/report-error.js
@@ -9,7 +9,7 @@ angular.module('biggraph').controller('ReportErrorCtrl', function($scope, $uibMo
     url: window.location.href,
     version: util.globals.version,
   };
-  $scope.debug = alert.details ? jsyaml.safeDump(debug, { sortKeys: true }) : undefined;
+  $scope.debug = alert.details ? jsyaml.safeDump(debug, { sortKeys: true, skipInvalid: true }) : undefined;
   $scope.title = alert.title || 'Reporting errors';
 
   $scope.close = function() {

--- a/web/app/scripts/splash/splash.html
+++ b/web/app/scripts/splash/splash.html
@@ -1,7 +1,7 @@
 <div class="container-fluid" id="splash">
   <div class="row">
     <div class="col-sm-12 big-brand">
-      <img src="images/logo.png" id="lynxkite-logo">
+      <a href="https://lynxkite.com/"><img src="images/logo.png" id="lynxkite-logo"></a>
       <h2 id="tagline" trusted-html="util.globals.tagline"></h2>
     </div>
   </div>
@@ -20,7 +20,7 @@
 
   <div class="row">
     <div class="col-sm-12">
-      <p class="version">{{ util.globals.version }}</p>
+      <p class="version"><a href="https://lynxkite.com/">{{ util.globals.version }}</a></p>
     </div>
   </div>
 </div>

--- a/web/app/scripts/util/user-menu.html
+++ b/web/app/scripts/util/user-menu.html
@@ -51,6 +51,11 @@
           <i class="glyphicon glyphicon-edit"></i> contact us
         </a>
       </li>
+      <li>
+        <a href="https://lynxkite.com/">
+          <i class="glyphicon glyphicon-lynxkite"></i> about
+        </a>
+      </li>
     </ul>
   </span>
 </span>

--- a/web/app/scripts/workspace/workspace-drawing-board.html
+++ b/web/app/scripts/workspace/workspace-drawing-board.html
@@ -1,8 +1,8 @@
 <div id="workspace-header" class="flat-toolbar">
   <div class="flat-toolbar-title">
-    <img src="favicon.png"
+    <a href="https://lynxkite.com/"><img src="favicon.png"
          height="50"
-         style="margin: -10px 10px 0 0;">
+         style="margin: -10px 10px 0 0;"></a>
     <span id="workspace-name">
       {{ getLastPart(workspace.name) }}
     </span>

--- a/web/app/styles/user-menu.css
+++ b/web/app/styles/user-menu.css
@@ -14,3 +14,10 @@
   right: 20px;
   z-index: 2; /* The bottom links should not be covered by the spark status indicator. */
 }
+
+.glyphicon-lynxkite {
+  width: 14px;
+  height: 14px;
+  background: url(/favicon.png);
+  background-size: cover;
+}


### PR DESCRIPTION
Some minor things noticed in RC1.

The link in the user menu:
![image](https://user-images.githubusercontent.com/1268018/85300580-0682e080-b4a7-11ea-8c6b-ca989b79cd8b.png)

The rest of the links are not visible, but work. 😄 

Converting Double attributes to Double being an error is an acute problem for migration. But it could also come up where the list to convert is a parametric parameter.