### PR TITLE
Fix type inference regex

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/Operations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/Operations.scala
@@ -531,8 +531,8 @@ object PythonUtilities {
   def inferInputs(code: String): Seq[String] = {
     val outputs = inferOutputs(code).map(_.replaceFirst(":.*", "")).toSet
     val mentions = api.flatMap { parent =>
-      val a = s"\\W$parent\\.\\w+".r.findAllMatchIn(code).map(_.matched.tail).toSeq
-      val b = s"""\\W$parent\\s*\\[\\s*['"](\\w+)['"]\\s*\\]""".r
+      val a = s"\\b$parent\\.\\w+".r.findAllMatchIn(code).map(_.matched).toSeq
+      val b = s"""\\b$parent\\s*\\[\\s*['"](\\w+)['"]\\s*\\]""".r
         .findAllMatchIn(code).map(m => s"$parent.${m.group(1)}").toSeq
       a ++ b
     }.toSet
@@ -540,9 +540,9 @@ object PythonUtilities {
   }
   def inferOutputs(code: String): Seq[String] = {
     api.flatMap { parent =>
-      val a = s"""\\W$parent\\.\\w+\\s*:\\s*[a-zA-Z0-9.]+""".r
-        .findAllMatchIn(code).map(_.matched.tail).toSeq
-      val b = s"""\\W$parent\\s*\\[\\s*['"](\\w+)['"]\\s*\\]\\s*:\\s*([a-zA-Z0-9.]+)""".r
+      val a = s"""\\b$parent\\.\\w+\\s*:\\s*[a-zA-Z0-9.]+""".r
+        .findAllMatchIn(code).map(_.matched).toSeq
+      val b = s"""\\b$parent\\s*\\[\\s*['"](\\w+)['"]\\s*\\]\\s*:\\s*([a-zA-Z0-9.]+)""".r
         .findAllMatchIn(code).map(m => s"$parent.${m.group(1)}: ${m.group(2)}").toSeq
       a ++ b
     }.sorted

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
@@ -66,7 +66,7 @@ es['score']: float = es.weight + es.comment.str.len()
 es['names']: str = 'from ' + vs.name[es.src].values + ' to ' + vs.name[es.dst].values
 graph_attributes.hello: str = graph_attributes.greeting.lower()
 graph_attributes.average_age: float = vs.age.mean()
-          """))
+          """.trim))
       .project
     assert(
       get(p.vertexAttributes("with_title").runtimeSafeCast[String]) ==


### PR DESCRIPTION
Fixes #42. `\W` is a non-word character, but it doesn't match for the start of the string. `\b` is word boundary and it's the perfect thing for this.