### PR TITLE
Use protoc-gen-go-grpc

### DIFF
--- a/sphynx/.gitignore
+++ b/sphynx/.gitignore
@@ -1,6 +1,4 @@
 proto/*.pb.go
-protoc/*
 *.zip
-*.exe
 *.pem
 /.build

--- a/sphynx/go.mod
+++ b/sphynx/go.mod
@@ -4,10 +4,7 @@ go 1.14
 
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200701075601-f25a014ab157
-	github.com/apache/thrift v0.0.0-20181112125854-24918abba929
-	github.com/golang/mock v1.4.3
 	github.com/golang/protobuf v1.4.2
-	github.com/google/flatbuffers v1.11.0
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/testing v0.0.0-20200608005635-e4eedbc6f7aa // indirect
 	github.com/xitongsys/parquet-go v1.5.2
@@ -17,5 +14,6 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31 // indirect
 	google.golang.org/grpc v1.30.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555 // indirect
 	google.golang.org/protobuf v1.25.0
 )

--- a/sphynx/go.sum
+++ b/sphynx/go.sum
@@ -22,7 +22,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/apache/arrow v0.0.0-20200701150040-cd3ed6058579 h1:+Nto1XPv+evq3d8tvplsvv28yunTMkhBX7x1UEVz3II=
 github.com/apache/arrow/go/arrow v0.0.0-20200701075601-f25a014ab157 h1:2m1jCFLu5UsiS666Z60WLcJ39KntcPrdiufF1rOxbZc=
 github.com/apache/arrow/go/arrow v0.0.0-20200701075601-f25a014ab157/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929 h1:ubPe2yRkS6A/X37s0TVGfuN42NV2h0BlzWj0X76RoUw=
@@ -115,7 +114,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lynxkite/lynxkite v0.0.0-20200701133447-646b0c7f6fc3 h1:2mLiO91DZN77TVs5yXbQlNvWsQgXUIMSWMcy53Nc+xM=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -313,6 +311,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555 h1:HYZFXlXJqim8gcoUICZN9oGXFPtw2GEBFm3ay9KZnxU=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/sphynx/lynxkite-sphynx/types.go
+++ b/sphynx/lynxkite-sphynx/types.go
@@ -4,10 +4,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	pb "github.com/lynxkite/lynxkite/sphynx/proto"
 	"sync"
 )
 
 type Server struct {
+	pb.UnimplementedSphynxServer
 	entityCache      EntityCache
 	dataDir          string
 	unorderedDataDir string

--- a/sphynx/proto_compile.sh
+++ b/sphynx/proto_compile.sh
@@ -17,12 +17,16 @@ fi
 # Generate the gRPC Java interfaces.
 GRPC_JAVA_VERSION="1.24.0"
 GRPC_JAVA=protoc-gen-grpc-java-$GRPC_JAVA_VERSION-linux-x86_64.exe
-wget -nc https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/$GRPC_JAVA_VERSION/$GRPC_JAVA
-chmod +x $REPO/$GRPC_JAVA
-protoc --plugin=protoc-gen-grpc-java=$REPO/$GRPC_JAVA --grpc-java_out=../app \
+wget -nc -P .build https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/$GRPC_JAVA_VERSION/$GRPC_JAVA
+chmod +x $REPO/.build/$GRPC_JAVA
+protoc --plugin=protoc-gen-grpc-java=$REPO/.build/$GRPC_JAVA --grpc-java_out=../app \
 	--proto_path=$PROTO_SOURCE_DIR $PROTO_SOURCE_FILE
 protoc -I=$PROTO_SOURCE_DIR --java_out=../app $PROTO_SOURCE_DIR/$PROTO_SOURCE_FILE
 
 # Generate the gRPC Go interfaces.
-go mod download
-PATH=${GOPATH:-~/go}/bin:$PATH protoc $PROTO_SOURCE_DIR/$PROTO_SOURCE_FILE --go_out=plugins=grpc:.
+go build -o .build/protoc-gen-go google.golang.org/protobuf/cmd/protoc-gen-go
+go build -o .build/protoc-gen-go-grpc google.golang.org/grpc/cmd/protoc-gen-go-grpc
+PATH=.build:$PATH protoc $PROTO_SOURCE_DIR/$PROTO_SOURCE_FILE --go-grpc_out=proto --go_out=proto
+# We don't need the whole directory tree. We are inside the module.
+mv proto/github.com/lynxkite/lynxkite/sphynx/proto/* proto/
+rm -rf proto/github.com

--- a/sphynx/sphynx_common.sh
+++ b/sphynx/sphynx_common.sh
@@ -3,3 +3,4 @@ PROTO_SOURCE_DIR="proto"
 PROTO_SOURCE_FILE="sphynx.proto"
 PATH="${REPO}/protoc/bin:${PATH}"
 GO_PKG=github.com/lynxkite/lynxkite/sphynx
+mkdir -p .build

--- a/sphynx/sphynx_compile.sh
+++ b/sphynx/sphynx_compile.sh
@@ -5,5 +5,4 @@ cd $(dirname $0)
 . sphynx_common.sh
 
 go fmt $GO_PKG/lynxkite-sphynx
-mkdir -p .build
 go build -o .build/lynxkite-sphynx $GO_PKG/lynxkite-sphynx


### PR DESCRIPTION
The same thing could actually also work with the old `protoc-gen-go`. But it looks like they just happen to be changing the whole thing, so this is also an upgrade.

[`github.com/golang/protobuf`](https://github.com/golang/protobuf) is the old one. [`google.golang.org/protobuf`](https://pkg.go.dev/mod/google.golang.org/protobuf) is the new one.

In the old thing the GRPC generator was a plugin of the Go `protoc` plugin. In the new thing it is a separate `protoc` plugin. (See https://github.com/grpc/grpc-go/pull/3453.)

The API is largely unchanged, but now requires this UnimplementedServer thing. (See https://github.com/grpc/grpc-go/pull/3657.)

We still depend on the old library in `go.mod`. This is because the generated code still imports the old library. Why does the new generator generate code that imports the old library?! I think either I've messed it up somehow, or they haven't updated the generated imports yet. Either way, everything works. We can figure it out later.