### PR TITLE
Make links in comments clickable

### DIFF
--- a/web/app/scripts/workspace/workspace-drawing-board.html
+++ b/web/app/scripts/workspace/workspace-drawing-board.html
@@ -208,7 +208,7 @@
         <foreignObject
           x="80" y="35" width="400" height="1000"
           ng-if="box.comment"
-          style = "pointer-events: none; opacity:0.95">
+          class="comment-box-text">
           <body xmlns="http://www.w3.org/1999/xhtml">
             <span class="workspace-comment" trusted-html="box.comment"></span>
           </body>

--- a/web/app/styles/workspace.css
+++ b/web/app/styles/workspace.css
@@ -307,3 +307,11 @@ op-editor > :first-child {
   border: 0;
   background: white;
 }
+
+.comment-box-text {
+  pointer-events: none;
+}
+
+.comment-box-text a {
+  pointer-events: auto;
+}


### PR DESCRIPTION
Fixes #15. I didn't move the 95% opacity to the CSS because it doesn't make any visual difference, but it may have a slight performance impact. Not sure why we had it.