### PR TITLE
Make search box fast

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,6 +17,7 @@ rules:
   linebreak-style: [error, unix]
   no-console: [warn]
   no-debugger: [warn]
+  no-unreachable: [warn]
   no-unused-vars: [warn]
   no-multi-spaces: [error]
   no-sequences: [error]

--- a/web/app/scripts/workspace/operation-selector.html
+++ b/web/app/scripts/workspace/operation-selector.html
@@ -41,7 +41,7 @@
     <h1>
       <input id="filter" ng-model="opFilter" ng-keyup="filterKey($event)" autocomplete="off">
     </h1>
-    <operation-selector-entry ng-repeat="op in filterAndSort(boxes, opFilter)"
+    <operation-selector-entry ng-repeat="op in filterAndSort(boxes, opFilter).slice(0, 20)"
         op="op"
         name="op.operationId"
         ondrag="localOndrag(op, $event)"


### PR DESCRIPTION
Fixes #52. You can't see more than 10-20 on the screen anyway. The list can be scrolled. But if Google is okay with displaying 10 results on a page maybe it's okay for us to not show them all either.

It's way faster on my laptop this way. Some stuff took 10+ seconds, but now everything is instantaneous.