### PR TITLE
Fix `proto_compile.sh` on Mac

### DIFF
--- a/sphynx/proto_compile.sh
+++ b/sphynx/proto_compile.sh
@@ -5,10 +5,17 @@
 cd $(dirname $0)
 . sphynx_common.sh
 
+# Check operating system for protobuc and grpc.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  OS_NAME="osx"
+else  # Assume it's Linux otherwise.
+  OS_NAME="linux"
+fi
+
 # Get protobuf compiler.
 if ! type "protoc" > /dev/null; then
   PROTOC_VERSION="3.10.0"
-  PROTOC_ZIP="protoc-$PROTOC_VERSION-linux-x86_64.zip"
+  PROTOC_ZIP="protoc-$PROTOC_VERSION-$OS_NAME-x86_64.zip"
   wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP
   mkdir -p protoc
   unzip -n $PROTOC_ZIP bin/protoc -d protoc
@@ -16,7 +23,7 @@ fi
 
 # Generate the gRPC Java interfaces.
 GRPC_JAVA_VERSION="1.24.0"
-GRPC_JAVA=protoc-gen-grpc-java-$GRPC_JAVA_VERSION-linux-x86_64.exe
+GRPC_JAVA=protoc-gen-grpc-java-$GRPC_JAVA_VERSION-$OS_NAME-x86_64.exe
 if ! -f $REPO/.build/$GRPC_JAVA; then
   wget -nv -P .build https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/$GRPC_JAVA_VERSION/$GRPC_JAVA
   chmod +x $REPO/.build/$GRPC_JAVA


### PR DESCRIPTION
**Description**
Building LynxKite with `make` doesn't work on a Mac, because the Linux version version of `protobuf` and `protoc-gen-grpc-java` are downloaded by default in `sphynx/proto_compile.sh`. In this pull request I'm addressing this by checking the operating system and downloading the correct version (either `osx` or `linux`).