### PR TITLE
Import & Export AVRO files

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -119,6 +119,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   registerExportToStructuredFile("Export to JSON")("json")
   registerExportToStructuredFile("Export to Parquet")("parquet")
   registerExportToStructuredFile("Export to ORC")("orc")
+  registerExportToStructuredFile("Export to AVRO")("avro")
 
   def registerExportToStructuredFile(id: String)(fileFormat: String) {
     register(id)(new ExportOperationToFile(_) {

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
@@ -201,6 +201,7 @@ class ImportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   register("Import Parquet")(new FileWithSchema(_) { val format = "parquet" })
   register("Import ORC")(new FileWithSchema(_) { val format = "orc" })
   register("Import JSON")(new FileWithSchema(_) { val format = "json" })
+  register("Import AVRO")(new FileWithSchema(_) { val format = "avro" })
 
   register("Import from Hive")(new ImportOperation(_) {
     params ++= List(

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,9 @@ libraryDependencies ++= Seq(
   // Used for encrypted connection with Sphynx.
   "io.netty" % "netty-tcnative-boringssl-static" % "2.0.26.Final",
   // This indirect dependency of ours is broken on Maven.
-  "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/geotools-releases/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar"
+  "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/geotools-releases/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
+  // Used for working with AVRO files. 
+  "org.apache.spark" %% "spark-avro" % sparkVersion.value
 )
 
 // We put the local Spark installation on the classpath for compilation and testing instead of using

--- a/dependency-licenses/scala.md
+++ b/dependency-licenses/scala.md
@@ -42,6 +42,8 @@ Apache | [Apache 2.0](https://opensource.org/licenses/Apache-2.0) | io.perfmark 
 Apache | [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0) | net.java.dev.jets3t # jets3t # 0.9.4 | <notextile></notextile>
 Apache | [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.scala-logging # scala-logging-api_2.11 # 2.1.2 | <notextile></notextile>
 Apache | [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.scala-logging # scala-logging-slf4j_2.11 # 2.1.2 | <notextile></notextile>
+Apache | [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) | org.apache.spark # spark-avro_2.11 # 2.4.3 | <notextile></notextile>
+Apache | [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) | org.apache.spark # spark-tags_2.11 # 2.4.3 | <notextile></notextile>
 Apache | [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0) | org.apache.sshd # sshd-core # 1.2.0 | <notextile></notextile>
 Apache | [Apache License](LICENSE.txt) | org.apache.httpcomponents # httpmime # 4.3.1 | <notextile></notextile>
 Apache | [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.ning # async-http-client # 1.8.14 | <notextile></notextile>
@@ -132,6 +134,7 @@ Apache | [Apache-2.0](http://opensource.org/licenses/Apache-2.0) | graphframes #
 Apache | [Similar to Apache License but with the acknowledgment clause removed](https://raw.github.com/hunterhacker/jdom/master/LICENSE.txt) | org.jdom # jdom2 # 2.0.6 | <notextile></notextile>
 Apache | [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | io.opencensus # opencensus-api # 0.21.0 | <notextile></notextile>
 Apache | [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | io.opencensus # opencensus-contrib-grpc-metrics # 0.21.0 | <notextile></notextile>
+Apache | [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.spark-project.spark # unused # 1.0.0 | <notextile></notextile>
 Apache | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.fasterxml.jackson.core # jackson-annotations # 2.6.5 | <notextile></notextile>
 Apache | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.fasterxml.jackson.core # jackson-core # 2.6.5 | <notextile></notextile>
 Apache | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.fasterxml.jackson.core # jackson-databind # 2.6.5 | <notextile></notextile>

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
@@ -89,4 +89,18 @@ class ExportBoxTest extends OperationsTestBase {
       box("Use table as vertices").project
     checkResult(importedAgain)
   }
+
+  test("Export to AVRO") {
+    val path = "EXPORTTEST$/tmp/exportedAVRO"
+    val exportTarget = HadoopFile(path)
+    exportTarget.deleteIfExists()
+    val exportResult = importTestFile.box("Export to AVRO", Map("path" -> path)).exportResult
+    dataManager.get(exportResult)
+    val importedAgain = importBox("Import AVRO", Map(
+      "filename" -> path))
+      .box("Use table as vertices").project
+    checkResult(importedAgain)
+
+    exportTarget.delete()
+  }
 }

--- a/web/app/help/operations/export-to-avro.asciidoc
+++ b/web/app/help/operations/export-to-avro.asciidoc
@@ -1,0 +1,26 @@
+### Export to AVRO 
+
+https://avro.apache.org/[Apache AVRO] is a row-oriented remote procedure call and data serialization framework. 
+
+====
+[p-path]#Path#::
+The distributed file-system path of the output file. It defaults to `<auto>`, in which case the
+path is auto generated from the parameters and the type of export (e.g. `Export to CSV`).
+This means that the same export operation with the same parameters always generates the same path.
+
+[p-version]#Version#::
+Version is the version number of the result of the export operation. It is a non negative integer.
+LynxKite treats export operations as other operations: it remembers the result (which in this case
+is the knowledge that the export was successfully done) and won't repeat the calculation. However,
+there might be a need to export an already exported table with the same set of parameters (e.g. the
+exported file is lost). In this case you need to change the version number, making that parameters
+are not the same as in the previous export.
+
+[p-for_download]#Export for download#::
+Set this to "true" if the purpose of this export is file download: in this case LynxKite will
+repartition the data into one single file, which will be downloaded. The default "no" will
+result in no such repartition: this performs much better when other, partition-aware tools
+are used to import the exported data.
+
+include::{g}[tag=save-mode-options]
+====

--- a/web/app/help/operations/import-avro.asciidoc
+++ b/web/app/help/operations/import-avro.asciidoc
@@ -1,0 +1,11 @@
+### Import AVRO 
+
+https://avro.apache.org/[Apache AVRO] is a row-oriented remote procedure call and data serialization framework. 
+
+====
+[p-filename]#File#::
+The distributed file-system path of the file. See <<prefixed-paths>> for more details on specifying
+paths.
+
+include::{g}[tag=import-box]
+====

--- a/web/app/help/operations/index.asciidoc
+++ b/web/app/help/operations/index.asciidoc
@@ -283,6 +283,8 @@ include::discard-vertex-attributes.asciidoc[]
 
 include::embed-vertices.asciidoc[]
 
+include::export-to-avro.asciidoc[]
+
 include::export-to-csv.asciidoc[]
 
 include::export-to-hive.asciidoc[]
@@ -348,6 +350,8 @@ include::graph-visualization.asciidoc[]
 include::grow-segmentation.asciidoc[]
 
 include::hash-vertex-attribute.asciidoc[]
+
+include::import-avro.asciidoc[]
 
 include::import-csv.asciidoc[]
 


### PR DESCRIPTION
Added support for importing and exporting AVRO files. 

Since the release of Spark 2.4, Spark SQL has built-in support for reading and writing Apache Avro data ([see here](https://spark.apache.org/docs/2.4.0/sql-data-sources-avro.html)). It was therefore relatively straightforward to add this functionality to LynxKite.