### PR TITLE
Added state.vertices, state.edges, etc.

### DIFF
--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -904,16 +904,15 @@ class State:
     '''Returns the edge attributes as a table.'''
     return self._select_all('edge_attributes')
 
-  @property
-  def segmentations(self):
-    '''Access a given segmentation.
+  def segmentations(self, name: str) -> 'SingleOutputAtomicBox':
+    '''Access a given segmentation by name.
 
     Example usage:
     ```
     graph = lk.createExampleGraph().findConnectedComponents(name='seg1')
-    segmentation = graph.segmentations['seg1']
+    segmentation = graph.segmentations('seg1')
     '''
-    return SegmentationPlaceholder(self)
+    return self.takeSegmentationAsBaseGraph(apply_to_graph='.' + name)
 
   def _select_all(self, table):
     return self.sql(f'select * from `{table}`')
@@ -1012,16 +1011,6 @@ class Placeholder:
 
   def __init__(self, value=None) -> None:
     self.value = value
-
-
-class SegmentationPlaceholder:
-  '''Placeholder for a segmentation.'''
-
-  def __init__(self, state: 'State'):
-    self.state = state
-
-  def __getitem__(self, name):
-    return self.state.takeSegmentationAsBaseGraph(apply_to_graph='.' + name)
 
 
 def _fn_id(fn: Callable):

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -904,8 +904,8 @@ class State:
     '''Returns the edge attributes as a table.'''
     return self._select_all('edge_attributes')
 
-  def segmentations(self, name: str) -> 'SingleOutputAtomicBox':
-    '''Access a given segmentation by name.
+  def segmentation(self, name: str) -> 'SingleOutputAtomicBox':
+    '''Returns the named segmentation as a base project.
 
     Example usage:
     ```

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -884,6 +884,40 @@ class State:
     _add_documentation_to_operation(f, name)
     return f
 
+  @property
+  def vertices(self) -> 'SingleOutputAtomicBox':
+    '''Returns the vertices as a table.'''
+    return self._select_all('vertices')
+
+  @property
+  def edges(self) -> 'SingleOutputAtomicBox':
+    '''Returns the edges as a table.'''
+    return self._select_all('edges')
+
+  @property
+  def graph_attributes(self) -> 'SingleOutputAtomicBox':
+    '''Returns the graph attributes as a table.'''
+    return self._select_all('graph_attributes')
+
+  @property
+  def edge_attributes(self) -> 'SingleOutputAtomicBox':
+    '''Returns the edge attributes as a table.'''
+    return self._select_all('edge_attributes')
+
+  @property
+  def segmentations(self):
+    '''Access a given segmentation.
+
+    Example usage:
+    ```
+    graph = lk.createExampleGraph().findConnectedComponents(name='seg1')
+    segmentation = graph.segmentations['seg1']
+    '''
+    return SegmentationPlaceholder(self)
+
+  def _select_all(self, table):
+    return self.sql(f'select * from `{table}`')
+
   def __dir__(self) -> Iterable[str]:
     return itertools.chain(super().__dir__(), self.operation_names())
 
@@ -978,6 +1012,16 @@ class Placeholder:
 
   def __init__(self, value=None) -> None:
     self.value = value
+
+
+class SegmentationPlaceholder:
+  '''Placeholder for a segmentation.'''
+
+  def __init__(self, state: 'State'):
+    self.state = state
+
+  def __getitem__(self, name):
+    return self.state.takeSegmentationAsBaseGraph(apply_to_graph='.' + name)
 
 
 def _fn_id(fn: Callable):

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -910,7 +910,7 @@ class State:
     Example usage:
     ```
     graph = lk.createExampleGraph().findConnectedComponents(name='seg1')
-    segmentation = graph.segmentations('seg1')
+    segmentation = graph.segmentation('seg1')
     '''
     return self.takeSegmentationAsBaseGraph(apply_to_graph='.' + name)
 

--- a/python/remote_api/tests/test_sql_shorthand.py
+++ b/python/remote_api/tests/test_sql_shorthand.py
@@ -90,3 +90,33 @@ class TestSQLShorthand(unittest.TestCase):
         'select count(*) as cnt from x', input_names='x').df()
     import pandas as pd
     self.assertTrue(df.equals(pd.DataFrame({'cnt': [4.0]})))
+
+  def test_vertices(self):
+    lk = lynx.kite.LynxKite()
+    g = lk.createExampleGraph()
+    df = g.vertices.df()
+    self.assertTrue(df.shape == (4, 6))
+
+  def test_edges(self):
+    lk = lynx.kite.LynxKite()
+    g = lk.createExampleGraph()
+    df = g.edges.df()
+    self.assertTrue(df.shape == (4, 14))
+
+  def test_graph_attributes(self):
+    lk = lynx.kite.LynxKite()
+    g = lk.createExampleGraph()
+    df = g.graph_attributes.df()
+    self.assertTrue(df.shape == (1, 3))
+
+  def test_edge_attributes(self):
+    lk = lynx.kite.LynxKite()
+    g = lk.createExampleGraph()
+    df = g.edge_attributes.df()
+    self.assertTrue(df.shape == (4, 2))
+
+  def test_segmentations(self):
+    lk = lynx.kite.LynxKite()
+    g = lk.createExampleGraph().findConnectedComponents(name='seg1')
+    df = g.segmentations['seg1'].vertices.df()
+    self.assertTrue(df.shape == (2, 2))

--- a/python/remote_api/tests/test_sql_shorthand.py
+++ b/python/remote_api/tests/test_sql_shorthand.py
@@ -118,5 +118,5 @@ class TestSQLShorthand(unittest.TestCase):
   def test_segmentations(self):
     lk = lynx.kite.LynxKite()
     g = lk.createExampleGraph().findConnectedComponents(name='seg1')
-    df = g.segmentations('seg1').vertices.df()
+    df = g.segmentation('seg1').vertices.df()
     self.assertTrue(df.shape == (2, 2))

--- a/python/remote_api/tests/test_sql_shorthand.py
+++ b/python/remote_api/tests/test_sql_shorthand.py
@@ -118,5 +118,5 @@ class TestSQLShorthand(unittest.TestCase):
   def test_segmentations(self):
     lk = lynx.kite.LynxKite()
     g = lk.createExampleGraph().findConnectedComponents(name='seg1')
-    df = g.segmentations['seg1'].vertices.df()
+    df = g.segmentations('seg1').vertices.df()
     self.assertTrue(df.shape == (2, 2))


### PR DESCRIPTION
**Description**
Added state properties for easily accessing `vertices`, `edges`, `graph_attributes`,  `edge_attributes` and `segmentations` in the Python Remote API. 

You can now do things such as:

```python
g = lk.createExampleGraph()
g.vertices
g.edges
g.edge_attributes
g.graph_attributes

g2 = g.findConnectedComponents(name="example")
g.segmentations["example"]
``` 