### PR TITLE
Show line numbers for long code

### DIFF
--- a/web/app/scripts/operation/operation-parameters.html
+++ b/web/app/scripts/operation/operation-parameters.html
@@ -16,7 +16,7 @@
     <div
       ui-ace="{
         mode: 'plain_text',
-        showGutter: false,
+        showGutter: true,
         rendererOptions: {
           fontSize: '16px'
         },
@@ -38,7 +38,7 @@
       <div
         ui-ace="{
           mode: '{{ param.payload.language }}',
-          showGutter: false,
+          showGutter: {{ parameters[param.id].split('\n').length > 5 }},
           rendererOptions: {
             fontSize: '16px'
           },


### PR DESCRIPTION
The line numbers don't pop in/out while typing but if you close and reopen the popup they will be or not be there depending on the number of lines. I think this is okay.

I've added this because I was getting an exception in line 53 of my Python code.