### PR TITLE
Small CSS fixes

### DIFF
--- a/web/app/styles/operation-selector.css
+++ b/web/app/styles/operation-selector.css
@@ -36,7 +36,7 @@
    * the bottom may extend beyond the screen. TODO: Any ideas for a fix? */
 }
 .operation-selector .category {
-  padding: 10px;
+  padding: 10px 0;
   text-align: center;
   font: 15px Arial;
   width: 35px;

--- a/web/app/styles/table-state-view.css
+++ b/web/app/styles/table-state-view.css
@@ -1,9 +1,6 @@
-table-state-view {
-  overflow: auto;
-}
-
 table-state-view > div {
   padding-top: 10px;
+  overflow: auto;
 }
 
 input.form-control#sample-rows {


### PR DESCRIPTION
I'm not sure many people noticed that the icons were slightly off-center. But the whole toolbar scrolling away in the table output popups always felt embarrassing in demos. Looks like the rule to make it scroll right was kind of there, just on the wrong element. That was probably the right element at some point. 😅 