### PR TITLE
Fix edge coloring with long fractional numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please add changes to "master", preferably ordered by their significance. (Most 
   now.
 - Added aggregation support for Vector attributes. (Elementwise average, sum, etc.)
 - Added an option to disable generated suffixes for aggregated variables.
+- Fix for edge coloring. ([#84](https://github.com/lynxkite/lynxkite/pull/85))
 
 ### 4.0.1
 

--- a/web/app/scripts/project/graph-view.js
+++ b/web/app/scripts/project/graph-view.js
@@ -1545,7 +1545,7 @@ angular.module('biggraph').directive('graphView', function(util, $compile, $time
 
       let color;
       if (colorKey && edge.attrs[colorKey].defined) {
-        color = (side.edgeAttrs.edgeColor.typeName === 'Double') ?
+        color = (side.edgeAttrs.edgeColor.typeName === 'number') ?
           colorMap[edge.attrs[colorKey].double] : colorMap[edge.attrs[colorKey].string];
       }
       const label = labelKey ? edge.attrs[labelKey].string : undefined;


### PR DESCRIPTION
Reported by Péter Vakhal. (Thanks!) The edge weights in the example graph are integers, so there's no problem there. The `double` and `string` values in DynamicValue are the same. But with non-integers the two can be different and then the lookup in the colormap does not find the entry.