### PR TITLE
Add support for Delta format

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -120,6 +120,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   registerExportToStructuredFile("Export to Parquet")("parquet")
   registerExportToStructuredFile("Export to ORC")("orc")
   registerExportToStructuredFile("Export to AVRO")("avro")
+  registerExportToStructuredFile("Export to Delta")("delta")
 
   def registerExportToStructuredFile(id: String)(fileFormat: String) {
     register(id)(new ExportOperationToFile(_) {

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
@@ -203,12 +203,7 @@ class ImportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   register("Import JSON")(new FileWithSchema(_) { val format = "json" })
   register("Import AVRO")(new FileWithSchema(_) { val format = "avro" })
 
-  register("Import Delta")(new FileWithSchema(_) {
-    val format = "delta"
-    params ++= List(
-      Param("timestampAsOf", "Data version (as timestamp)"),
-      Param("versionAsOf", "Data version"))
-  })
+  register("Import Delta")(new FileWithSchema(_) { val format = "delta" })
 
   register("Import from Hive")(new ImportOperation(_) {
     params ++= List(

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
@@ -203,7 +203,23 @@ class ImportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   register("Import JSON")(new FileWithSchema(_) { val format = "json" })
   register("Import AVRO")(new FileWithSchema(_) { val format = "avro" })
 
-  register("Import Delta")(new FileWithSchema(_) { val format = "delta" })
+  register("Import Delta")(new FileWithSchema(_) {
+    val format = "delta"
+    params ++= List(
+      Param("version_as_of", "versionAsOf"))
+
+    override def getRawDataFrame(context: spark.sql.SQLContext) = {
+      val hadoopFile = graph_util.HadoopFile(params("filename"))
+      hadoopFile.assertReadAllowedFrom(user)
+      FileImportValidator.checkFileHasContents(hadoopFile)
+
+      if (params("version_as_of").isEmpty) {
+        context.read.format(format).load(hadoopFile.resolvedName)
+      } else {
+        context.read.format(format).option("versionAsOf", params("version_as_of")).load(hadoopFile.resolvedName)
+      }
+    }
+  })
 
   register("Import from Hive")(new ImportOperation(_) {
     params ++= List(

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
@@ -203,6 +203,13 @@ class ImportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
   register("Import JSON")(new FileWithSchema(_) { val format = "json" })
   register("Import AVRO")(new FileWithSchema(_) { val format = "avro" })
 
+  register("Import Delta")(new FileWithSchema(_) {
+    val format = "delta"
+    params ++= List(
+      Param("timestampAsOf", "Data version (as timestamp)"),
+      Param("versionAsOf", "Data version"))
+  })
+
   register("Import from Hive")(new ImportOperation(_) {
     params ++= List(
       Param("hive_table", "Hive table"),

--- a/app/com/lynxanalytics/biggraph/spark_util/BigGraphSparkContext.scala
+++ b/app/com/lynxanalytics/biggraph/spark_util/BigGraphSparkContext.scala
@@ -295,6 +295,8 @@ class BigGraphKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[org.apache.spark.sql.types.DecimalType])
     kryo.register(classOf[org.apache.spark.sql.types.Decimal$DecimalAsIfIntegral$])
     kryo.register(classOf[org.apache.spark.sql.types.Decimal$DecimalIsFractional$])
+    kryo.register(scala.collection.mutable.ListBuffer().getClass)
+    kryo.register(classOf[org.apache.spark.sql.delta.actions.AddFile])
 
     // Add new stuff just above this line! Thanks.
     // Adding Foo$mcXXX$sp? It is a type specialization. Register the decoded type instead!

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,9 @@ libraryDependencies ++= Seq(
   // This indirect dependency of ours is broken on Maven.
   "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/geotools-releases/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
   // Used for working with AVRO files. 
-  "org.apache.spark" %% "spark-avro" % sparkVersion.value
+  "org.apache.spark" %% "spark-avro" % sparkVersion.value,
+  // Used for working with Delta tables.
+  "io.delta" %% "delta-core" % "0.6.1"
 )
 
 // We put the local Spark installation on the classpath for compilation and testing instead of using

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
@@ -103,4 +103,19 @@ class ExportBoxTest extends OperationsTestBase {
 
     exportTarget.delete()
   }
+
+  test("Export to Delta") {
+    val path = "EXPORTTEST$/tmp/exportedDeltaTable"
+    val exportTarget = HadoopFile(path)
+    exportTarget.deleteIfExists()
+    val exportResult = importTestFile.box("Export to Delta", Map("path" -> path)).exportResult
+    dataManager.get(exportResult)
+    val importedAgain = importBox("Import Delta", Map(
+      "filename" -> path))
+      .box("Use table as vertices").project
+    checkResult(importedAgain)
+
+    exportTarget.delete()
+  }
+
 }

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ExportBoxTest.scala
@@ -118,4 +118,20 @@ class ExportBoxTest extends OperationsTestBase {
     exportTarget.delete()
   }
 
+  test("Export to Delta and re-import with version") {
+    val path = "EXPORTTEST$/tmp/exportedDeltaTable"
+    val exportTarget = HadoopFile(path)
+    exportTarget.deleteIfExists()
+
+    val exportResult = importTestFile.box("Export to Delta", Map("path" -> path)).exportResult
+    dataManager.get(exportResult)
+
+    val importedAgain = importBox("Import Delta", Map(
+      "filename" -> path, "version_as_of" -> "0"))
+      .box("Use table as vertices").project
+    checkResult(importedAgain)
+
+    exportTarget.delete()
+  }
+
 }

--- a/web/app/help/operations/export-to-delta.asciidoc
+++ b/web/app/help/operations/export-to-delta.asciidoc
@@ -1,0 +1,26 @@
+### Export to Delta
+
+Export data to a Delta table.
+
+====
+[p-path]#Path#::
+The distributed file-system path of the output file. It defaults to `<auto>`, in which case the
+path is auto generated from the parameters and the type of export (e.g. `Export to CSV`).
+This means that the same export operation with the same parameters always generates the same path.
+
+[p-version]#Version#::
+Version is the version number of the result of the export operation. It is a non negative integer.
+LynxKite treats export operations as other operations: it remembers the result (which in this case
+is the knowledge that the export was successfully done) and won't repeat the calculation. However,
+there might be a need to export an already exported table with the same set of parameters (e.g. the
+exported file is lost). In this case you need to change the version number, making that parameters
+are not the same as in the previous export.
+
+[p-for_download]#Export for download#::
+Set this to "true" if the purpose of this export is file download: in this case LynxKite will
+repartition the data into one single file, which will be downloaded. The default "no" will
+result in no such repartition: this performs much better when other, partition-aware tools
+are used to import the exported data.
+
+include::{g}[tag=save-mode-options]
+====

--- a/web/app/help/operations/import-delta.asciidoc
+++ b/web/app/help/operations/import-delta.asciidoc
@@ -2,15 +2,13 @@
 
 Import a Delta Table.
 
-https://avro.apache.org/[Apache AVRO] is a row-oriented remote procedure call and data serialization framework.
-
 ====
 [p-filename]#File#::
 The distributed file-system path of the file. See <<prefixed-paths>> for more details on specifying
 paths.
 
 [p-version_as_of]#Version As Of$::
-Version of the Delta table to be important. Empty value corresponds to the latest version.
+Version of the Delta table to be imported. The empty string corresponds to the latest version.
 
 include::{g}[tag=import-box]
 ====

--- a/web/app/help/operations/import-delta.asciidoc
+++ b/web/app/help/operations/import-delta.asciidoc
@@ -1,0 +1,16 @@
+### Import Delta
+
+Import a Delta Table.
+
+https://avro.apache.org/[Apache AVRO] is a row-oriented remote procedure call and data serialization framework.
+
+====
+[p-filename]#File#::
+The distributed file-system path of the file. See <<prefixed-paths>> for more details on specifying
+paths.
+
+[p-version_as_of]#Version As Of$::
+Version of the Delta table to be important. Empty value corresponds to the latest version.
+
+include::{g}[tag=import-box]
+====

--- a/web/app/help/operations/index.asciidoc
+++ b/web/app/help/operations/index.asciidoc
@@ -287,6 +287,8 @@ include::export-to-avro.asciidoc[]
 
 include::export-to-csv.asciidoc[]
 
+include::export-to-delta.asciidoc[]
+
 include::export-to-hive.asciidoc[]
 
 include::export-to-jdbc.asciidoc[]
@@ -356,6 +358,8 @@ include::hash-vertex-attribute.asciidoc[]
 include::import-avro.asciidoc[]
 
 include::import-csv.asciidoc[]
+
+include::import-delta.asciidoc[]
 
 include::import-from-hive.asciidoc[]
 


### PR DESCRIPTION
**Description**
In this pull request I have added support for reading and writing to Delta Lake in LynxKite. "Delta Lake is an open-source storage layer that brings ACID transactions to to Apache Spark and big data workloads." \[1\] 

I used Delta version `0.6.1`, since versions >= `0.7.x` require Spark 3.0. 

\[1\]: https://docs.delta.io/latest/index.html