### PR TITLE
Neo4j export

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -172,11 +172,11 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       Map(context.box.output(
         context.meta.outputs(0)) -> BoxOutputState.from(exportResult, params.toMap - "password"))
     }
+    def getAttribute(a: String): com.lynxanalytics.biggraph.graph_api.Attribute[_]
     def exportResult() = {
       val keys = splitParam("keys")
       val attrs = (splitParam("to_export") ++ keys).toSet.toList
-      val t = graph_operations.AttributesToTable.run(
-        attrs.map(a => a -> project.vertexAttributes(a)))
+      val t = graph_operations.AttributesToTable.run(attrs.map(a => a -> getAttribute(a)))
       assert(keys.nonEmpty, "You have to choose one or more attributes to use as the keys for identifying the nodes in Neo4j.")
       val op = graph_operations.ExportAttributesToNeo4j(
         params("url"), params("username"), params("password"), params("labels"), keys,
@@ -196,6 +196,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
           options = project.vertexAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.vertexAttrList, multipleChoice = true))
       val nodesOrRelationships = "nodes"
+      def getAttribute(a: String) = project.vertexAttributes(a)
     })
   registerOp(
     "Export edge attributes to Neo4j", defaultIcon, ExportOperations,
@@ -207,7 +208,8 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
           // Cannot join on internal ID ("<id>") and stuff like that.
           options = project.edgeAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.edgeAttrList, multipleChoice = true))
-      val nodesOrRelationships = "edges"
+      val nodesOrRelationships = "relationships"
+      def getAttribute(a: String) = project.edgeAttributes(a)
     })
 
   registerOp(

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -190,7 +190,9 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       import Operation.Implicits._
       params ++= List(
         Param("labels", "Node labels", defaultValue = ""),
-        Choice("keys", "Attribute to use as key", options = project.vertexAttrList, multipleChoice = true),
+        Choice("keys", "Attribute to use as key",
+          // Cannot join on internal ID ("<id>") and stuff like that.
+          options = project.vertexAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.vertexAttrList, multipleChoice = true))
       val nodesOrRelationships = "nodes"
     })
@@ -200,7 +202,9 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       import Operation.Implicits._
       params ++= List(
         Param("labels", "Relationship labels", defaultValue = ""),
-        Choice("keys", "Attribute to use as key", options = project.edgeAttrList, multipleChoice = true),
+        Choice("keys", "Attribute to use as key",
+          // Cannot join on internal ID ("<id>") and stuff like that.
+          options = project.edgeAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.edgeAttrList, multipleChoice = true))
       val nodesOrRelationships = "edges"
     })

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -164,7 +164,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
     lazy val project = projectInput("graph")
     val nodesOrRelationships: String
     override def enabled = FEStatus.enabled
-    override def trigger(wc: WorkspaceController, gdc: GraphDrawingController) = {
+    override def trigger(wc: WorkspaceController, gdc: GraphDrawingController): scala.concurrent.Future[Unit] = {
       gdc.getComputeBoxResult(List(exportResult.gUID))
     }
     override def getOutputs(): Map[BoxOutput, BoxOutputState] = {
@@ -225,7 +225,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
           options = List(FEOption("", "")) ++ project.edgeAttrList[String]))
       lazy val project = projectInput("graph")
       override def enabled = FEStatus.enabled
-      override def trigger(wc: WorkspaceController, gdc: GraphDrawingController) = {
+      override def trigger(wc: WorkspaceController, gdc: GraphDrawingController): scala.concurrent.Future[Unit] = {
         gdc.getComputeBoxResult(List(exportResult.gUID))
       }
       override def getOutputs(): Map[BoxOutput, BoxOutputState] = {

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -160,7 +160,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
       Param("username", "Neo4j username", defaultValue = "neo4j"),
       Param("password", "Neo4j password", defaultValue = "neo4j"),
-      NonNegInt("version", "Snapshot revision ID", default = 1))
+      NonNegInt("version", "Export repetition ID", default = 1))
     lazy val project = projectInput("graph")
     val nodesOrRelationships: String
     override def enabled = FEStatus.enabled
@@ -191,7 +191,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       import Operation.Implicits._
       params ++= List(
         Param("labels", "Node labels", defaultValue = ""),
-        Choice("keys", "Attribute to use as key",
+        Choice("keys", "Attribute(s) to use as key",
           // Cannot join on internal ID ("<id>") and stuff like that.
           options = project.vertexAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.vertexAttrList, multipleChoice = true))
@@ -203,7 +203,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       import Operation.Implicits._
       params ++= List(
         Param("labels", "Relationship labels", defaultValue = ""),
-        Choice("keys", "Attribute to use as key",
+        Choice("keys", "Attribute(s) to use as key",
           // Cannot join on internal ID ("<id>") and stuff like that.
           options = project.edgeAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.edgeAttrList, multipleChoice = true))
@@ -218,7 +218,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
         Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
         Param("username", "Neo4j username", defaultValue = "neo4j"),
         Param("password", "Neo4j password", defaultValue = "neo4j"),
-        NonNegInt("version", "Snapshot revision ID", default = 1),
+        NonNegInt("version", "Export repetition ID", default = 1),
         Choice("node_labels", "Attribute with node labels",
           options = List(FEOption("", "")) ++ project.vertexAttrList[String]),
         Choice("relationship_type", "Attribute with relationship type",

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -160,7 +160,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
       Param("username", "Neo4j username", defaultValue = "neo4j"),
       Param("password", "Neo4j password", defaultValue = "neo4j"),
-      NonNegInt("version", "Revision ID", default = 1))
+      NonNegInt("version", "Snapshot revision ID", default = 1))
     lazy val project = projectInput("graph")
     val nodesOrRelationships: String
     override def enabled = FEStatus.enabled
@@ -175,11 +175,12 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
     def exportResult() = {
       val keys = splitParam("keys")
       val attrs = (splitParam("to_export") ++ keys).toSet.toList
-      val t = graph_operations.AttributesToTable.run(attrs.map(a => a -> project.vertexAttributes(a)))
-      //  .map(k => s"$k:$k").mkString(",")
+      val t = graph_operations.AttributesToTable.run(
+        attrs.map(a => a -> project.vertexAttributes(a)))
       assert(keys.nonEmpty, "You have to choose one or more attributes to use as the keys for identifying the nodes in Neo4j.")
       val op = graph_operations.ExportAttributesToNeo4j(
-        params("url"), params("username"), params("password"), params("labels"), keys, params("version").toInt, nodesOrRelationships)
+        params("url"), params("username"), params("password"), params("labels"), keys,
+        params("version").toInt, nodesOrRelationships)
       op(op.t, t).result.exportResult
     }
   }
@@ -207,5 +208,42 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
           options = project.edgeAttrList.filter(!_.id.startsWith("<")), multipleChoice = true),
         Choice("to_export", "Exported attributes", options = project.edgeAttrList, multipleChoice = true))
       val nodesOrRelationships = "edges"
+    })
+
+  registerOp(
+    "Export graph to Neo4j", defaultIcon, ExportOperations,
+    List("graph"), List("exported"), new TriggerableOperation(_) {
+      import Operation.Implicits._
+      params ++= List(
+        Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
+        Param("username", "Neo4j username", defaultValue = "neo4j"),
+        Param("password", "Neo4j password", defaultValue = "neo4j"),
+        NonNegInt("version", "Snapshot revision ID", default = 1),
+        Choice("node_labels", "Attribute with node labels",
+          options = List(FEOption("", "")) ++ project.vertexAttrList[String]),
+        Choice("relationship_type", "Attribute with relationship type",
+          options = List(FEOption("", "")) ++ project.edgeAttrList[String]))
+      lazy val project = projectInput("graph")
+      override def enabled = FEStatus.enabled
+      override def trigger(wc: WorkspaceController, gdc: GraphDrawingController) = {
+        gdc.getComputeBoxResult(List(exportResult.gUID))
+      }
+      override def getOutputs(): Map[BoxOutput, BoxOutputState] = {
+        params.validate()
+        Map(context.box.output(
+          context.meta.outputs(0)) -> BoxOutputState.from(exportResult, params.toMap - "password"))
+      }
+      def exportResult() = {
+        val vsAttr = project.vertexAttributes.toMap +
+          (graph_operations.ExportGraphToNeo4j.VID -> project.vertexSet.idAttribute)
+        val esAttr = project.edgeAttributes.toMap +
+          (graph_operations.ExportGraphToNeo4j.SRCDST -> project.edgeBundle.srcDstAttribute)
+        val vs = graph_operations.AttributesToTable.run(vsAttr)
+        val es = graph_operations.AttributesToTable.run(esAttr)
+        val op = graph_operations.ExportGraphToNeo4j(
+          params("url"), params("username"), params("password"), params("node_labels"),
+          params("relationship_type"), params("version").toInt)
+        op(op.vs, vs)(op.es, es).result.exportResult
+      }
     })
 }

--- a/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
@@ -9,9 +9,7 @@ object ExportAttributesToNeo4j extends OpFromJson {
   class Input extends MagicInputSignature {
     val t = table
   }
-  class Output(implicit
-      instance: MetaGraphOperationInstance,
-      inputs: Input) extends MagicOutput(instance) {
+  class Output(implicit instance: MetaGraphOperationInstance) extends MagicOutput(instance) {
     val exportResult = scalar[String]
   }
   def fromJson(j: JsValue) = ExportAttributesToNeo4j(
@@ -20,11 +18,26 @@ object ExportAttributesToNeo4j extends OpFromJson {
     (j \ "nodesOrRelationships").as[String])
 }
 
+case class Neo4jConnection(url: String, username: String, password: String) {
+  def send(df: spark.sql.DataFrame, query: String) {
+    df.write
+      .format("org.neo4j.spark.DataSource")
+      .option("authentication.type", "basic")
+      .option("authentication.basic.username", username)
+      .option("authentication.basic.password", password)
+      .option("url", url)
+      .option("query", query)
+      .save()
+  }
+}
+
 case class ExportAttributesToNeo4j(
-    url: String, username: String, password: String, labels: String, keys: Seq[String], version: Long, nodesOrRelationships: String)
+    url: String, username: String, password: String, labels: String, keys: Seq[String],
+    version: Long, nodesOrRelationships: String)
   extends SparkOperation[ExportAttributesToNeo4j.Input, ExportAttributesToNeo4j.Output] {
+  val neo = Neo4jConnection(url, username, password)
   @transient override lazy val inputs = new ExportAttributesToNeo4j.Input()
-  def outputMeta(instance: MetaGraphOperationInstance) = new ExportAttributesToNeo4j.Output()(instance, inputs)
+  def outputMeta(instance: MetaGraphOperationInstance) = new ExportAttributesToNeo4j.Output()(instance)
   override def toJson = Json.obj(
     "url" -> url, "username" -> username, "password" -> password, "labels" -> labels,
     "keys" -> keys, "version" -> version, "nodesOrRelationships" -> nodesOrRelationships)
@@ -34,19 +47,88 @@ case class ExportAttributesToNeo4j(
     output: OutputBuilder,
     rc: RuntimeContext): Unit = {
     implicit val ds = inputDatas
-    implicit val sd = rc.sparkDomain
+    // Drop null keys.
     val df = keys.foldLeft(inputs.t.df)((df, key) => df.filter(df(key).isNotNull))
     val keyMatch = keys.map(k => s"`$k`: event.`$k`").mkString(", ")
-    val query = s"MERGE (n$labels {$keyMatch}) SET n += event"
-    df.write
-      .format("org.neo4j.spark.DataSource")
-      .mode(SaveMode.Overwrite)
-      .option("authentication.type", "basic")
-      .option("authentication.basic.username", username)
-      .option("authentication.basic.password", password)
-      .option("url", url)
-      .option("query", query)
-      .save()
+    val query = nodesOrRelationships match {
+      case "nodes" => s"MATCH (n$labels {$keyMatch}) SET n += event"
+      case "relationships" => s"MATCH ()-[r$labels {$keyMatch}]-() SET r += event"
+    }
+    neo.send(df, query)
+    val exportResult = "Export done."
+    output(o.exportResult, exportResult)
+  }
+}
+
+object ExportGraphToNeo4j extends OpFromJson {
+  class Input extends MagicInputSignature {
+    val vs = table
+    val es = table
+  }
+  class Output(implicit instance: MetaGraphOperationInstance) extends MagicOutput(instance) {
+    val exportResult = scalar[String]
+  }
+  def fromJson(j: JsValue) = ExportGraphToNeo4j(
+    (j \ "url").as[String], (j \ "username").as[String], (j \ "password").as[String],
+    (j \ "nodeLabelsColumn").as[String], (j \ "relationshipTypeColumn").as[String],
+    (j \ "version").as[Long])
+  val VID = "!LynxKite ID"
+  val SRCDST = "!LynxKite endpoint IDs"
+  val SRCID = "!Source LynxKite ID"
+  val DSTID = "!Destination LynxKite ID"
+}
+
+case class ExportGraphToNeo4j(
+    url: String, username: String, password: String, nodeLabelsColumn: String,
+    relationshipTypeColumn: String, version: Long)
+  extends SparkOperation[ExportGraphToNeo4j.Input, ExportGraphToNeo4j.Output] {
+  import ExportGraphToNeo4j._
+  val neo = Neo4jConnection(url, username, password)
+  @transient override lazy val inputs = new ExportGraphToNeo4j.Input()
+  def outputMeta(instance: MetaGraphOperationInstance) = new ExportGraphToNeo4j.Output()(instance)
+  override def toJson = Json.obj(
+    "url" -> url, "username" -> username, "password" -> password,
+    "nodeLabelsColumn" -> nodeLabelsColumn, "relationshipTypeColumn" -> relationshipTypeColumn,
+    "version" -> version)
+  def execute(
+    inputDatas: DataSet,
+    o: ExportGraphToNeo4j.Output,
+    output: OutputBuilder,
+    rc: RuntimeContext): Unit = {
+    implicit val ds = inputDatas
+    val F = spark.sql.functions
+    // Prefix the internal IDs with this operation's GUID so different exports don't collide.
+    val guid = F.lit(this.gUID.toString + "-")
+    val vs = inputs.vs.df
+      .withColumn(VID, F.concat(guid, F.col(VID)))
+    val es = inputs.es.df
+      .withColumn(SRCID, F.concat(guid, F.col(SRCDST + "._1")))
+      .withColumn(DSTID, F.concat(guid, F.col(SRCDST + "._2")))
+      .drop(SRCDST)
+    if (nodeLabelsColumn.isEmpty) {
+      neo.send(vs, s"""
+        CREATE (n)
+        SET n += event
+      """)
+    } else {
+      neo.send(vs, s"""
+        CALL apoc.create.node(split(event.`$nodeLabelsColumn`, ','), event) YIELD node
+        RETURN 1
+      """)
+    }
+    if (relationshipTypeColumn.isEmpty) {
+      neo.send(es, s"""
+      MATCH (src {`$VID`: event.`$SRCID`}), (dst {`$VID`: event.`$DSTID`})
+      CREATE (src)-[r:EDGE]->(dst)
+      SET r += event
+    """)
+    } else {
+      neo.send(es, s"""
+      MATCH (src {`$VID`: event.`$SRCID`}), (dst {`$VID`: event.`$DSTID`})
+      CALL apoc.create.relationship(src, event.`$relationshipTypeColumn`, event, dst) YIELD rel
+      RETURN 1
+    """)
+    }
     val exportResult = "Export done."
     output(o.exportResult, exportResult)
   }

--- a/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
@@ -35,7 +35,7 @@ case class ExportAttributesToNeo4j(
     rc: RuntimeContext): Unit = {
     implicit val ds = inputDatas
     implicit val sd = rc.sparkDomain
-    val df = inputs.t.df
+    val df = keys.foldLeft(inputs.t.df)((df, key) => df.filter(df(key).isNotNull))
     val keyMatch = keys.map(k => s"`$k`: event.`$k`").mkString(", ")
     val query = s"MERGE (n$labels {$keyMatch}) SET n += event"
     df.write

--- a/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
@@ -1,0 +1,53 @@
+package com.lynxanalytics.biggraph.graph_operations
+
+import com.lynxanalytics.biggraph.graph_api._
+import com.lynxanalytics.biggraph.graph_util.HadoopFile
+import org.apache.spark
+import org.apache.spark.sql.SaveMode
+
+object ExportAttributesToNeo4j extends OpFromJson {
+  class Input extends MagicInputSignature {
+    val t = table
+  }
+  class Output(implicit
+      instance: MetaGraphOperationInstance,
+      inputs: Input) extends MagicOutput(instance) {
+    val exportResult = scalar[String]
+  }
+  def fromJson(j: JsValue) = ExportAttributesToNeo4j(
+    (j \ "url").as[String], (j \ "username").as[String], (j \ "password").as[String],
+    (j \ "labels").as[String], (j \ "keys").as[Seq[String]], (j \ "version").as[Long],
+    (j \ "nodesOrRelationships").as[String])
+}
+
+case class ExportAttributesToNeo4j(
+    url: String, username: String, password: String, labels: String, keys: Seq[String], version: Long, nodesOrRelationships: String)
+  extends SparkOperation[ExportAttributesToNeo4j.Input, ExportAttributesToNeo4j.Output] {
+  @transient override lazy val inputs = new ExportAttributesToNeo4j.Input()
+  def outputMeta(instance: MetaGraphOperationInstance) = new ExportAttributesToNeo4j.Output()(instance, inputs)
+  override def toJson = Json.obj(
+    "url" -> url, "username" -> username, "password" -> password, "labels" -> labels,
+    "keys" -> keys, "version" -> version, "nodesOrRelationships" -> nodesOrRelationships)
+  def execute(
+    inputDatas: DataSet,
+    o: ExportAttributesToNeo4j.Output,
+    output: OutputBuilder,
+    rc: RuntimeContext): Unit = {
+    implicit val ds = inputDatas
+    implicit val sd = rc.sparkDomain
+    val df = inputs.t.df
+    val keyMatch = keys.map(k => s"`$k`: event.`$k`").mkString(", ")
+    val query = s"MERGE (n$labels {$keyMatch}) SET n += event"
+    df.write
+      .format("org.neo4j.spark.DataSource")
+      .mode(SaveMode.Overwrite)
+      .option("authentication.type", "basic")
+      .option("authentication.basic.username", username)
+      .option("authentication.basic.password", password)
+      .option("url", url)
+      .option("query", query)
+      .save()
+    val exportResult = "Export done."
+    output(o.exportResult, exportResult)
+  }
+}

--- a/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/ExportToNeo4j.scala
@@ -18,7 +18,7 @@ object ExportAttributesToNeo4j extends OpFromJson {
     (j \ "nodesOrRelationships").as[String])
 }
 
-case class Neo4jConnection(url: String, username: String, password: String) {
+case class Neo4jConnectionParameters(url: String, username: String, password: String) {
   def send(df: spark.sql.DataFrame, query: String) {
     df.write
       .format("org.neo4j.spark.DataSource")
@@ -35,7 +35,7 @@ case class ExportAttributesToNeo4j(
     url: String, username: String, password: String, labels: String, keys: Seq[String],
     version: Long, nodesOrRelationships: String)
   extends SparkOperation[ExportAttributesToNeo4j.Input, ExportAttributesToNeo4j.Output] {
-  val neo = Neo4jConnection(url, username, password)
+  val neo = Neo4jConnectionParameters(url, username, password)
   @transient override lazy val inputs = new ExportAttributesToNeo4j.Input()
   def outputMeta(instance: MetaGraphOperationInstance) = new ExportAttributesToNeo4j.Output()(instance)
   override def toJson = Json.obj(
@@ -83,7 +83,7 @@ case class ExportGraphToNeo4j(
     relationshipTypeColumn: String, version: Long)
   extends SparkOperation[ExportGraphToNeo4j.Input, ExportGraphToNeo4j.Output] {
   import ExportGraphToNeo4j._
-  val neo = Neo4jConnection(url, username, password)
+  val neo = Neo4jConnectionParameters(url, username, password)
   @transient override lazy val inputs = new ExportGraphToNeo4j.Input()
   def outputMeta(instance: MetaGraphOperationInstance) = new ExportGraphToNeo4j.Output()(instance)
   override def toJson = Json.obj(

--- a/app/com/lynxanalytics/biggraph/graph_util/Scripting.scala
+++ b/app/com/lynxanalytics/biggraph/graph_util/Scripting.scala
@@ -72,6 +72,11 @@ object Scripting {
       val op = graph_operations.AddReversedEdges()
       op(op.es, self).result.esPlus
     }
+
+    def srcDstAttribute: Attribute[(ID, ID)] = {
+      val op = graph_operations.EdgeBundleAsAttribute()
+      op(op.edges, self).result.attr
+    }
   }
 
   implicit class RichContainedAttribute[T](

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,9 @@ libraryDependencies ++= Seq(
   "javax.media" % "jai_core" % "1.1.3" from "https://repo.osgeo.org/repository/geotools-releases/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
   // Used for working with AVRO files. 
   "org.apache.spark" %% "spark-avro" % sparkVersion.value,
+  // For Neo4j tests.
+  "org.testcontainers" % "testcontainers" % "1.14.3" % Test,
+  "org.testcontainers" % "neo4j" % "1.14.3" % Test,
   // Used for working with Delta tables.
   "io.delta" %% "delta-core" % "0.6.1"
 )

--- a/test/com/lynxanalytics/biggraph/frontend_operations/Neo4jExportImportTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/Neo4jExportImportTest.scala
@@ -1,0 +1,53 @@
+package com.lynxanalytics.biggraph.frontend_operations
+
+import com.lynxanalytics.biggraph.controllers.DirectoryEntry
+import com.lynxanalytics.biggraph.graph_api.Edge
+import com.lynxanalytics.biggraph.graph_api.Scripting._
+import com.lynxanalytics.biggraph.graph_api.GraphTestUtils._
+
+class Neo4jContainer
+  extends org.testcontainers.containers.Neo4jContainer[Neo4jContainer]("neo4j:4.0.8-enterprise")
+
+class Neo4jExportImportTest extends OperationsTestBase {
+  val server = new Neo4jContainer()
+    .withoutAuthentication
+    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+
+  def exportExampleGraph() = {
+    val res = box("Create example graph")
+      .box("Export graph to Neo4j", Map("url" -> server.getBoltUrl)).exportResult
+    dataManager.get(res)
+  }
+
+  test("full graph export and import") {
+    server.start()
+    exportExampleGraph()
+    val p = importBox("Import from Neo4j", Map("url" -> server.getBoltUrl)).project
+    assert(p.vertexAttributes.toMap.keySet == Set(
+      "!LynxKite ID", "!LynxKite export timestamp", "<id>", "<labels>",
+      "age", "gender", "id", "income", "location", "name"))
+    assert(p.edgeAttributes.toMap.keySet == Set(
+      "<rel_id>", "<rel_type>", "<source_id>", "<target_id>", "comment", "weight"))
+    assert(get(p.vertexAttributes("name")).values.toSet == Set("Adam", "Bob", "Eve", "Isolated Joe"))
+    assert(get(p.edgeAttributes("weight")).values.toSet == Set(1.0, 2.0, 3.0, 4.0))
+    server.stop()
+  }
+
+  test("attribute export") {
+    server.start()
+    exportExampleGraph()
+    val g = box("Create example graph").box("Compute PageRank").box("Compute dispersion")
+    dataManager.get(g.box(
+      "Export vertex attributes to Neo4j",
+      Map("url" -> server.getBoltUrl, "keys" -> "name", "to_export" -> "page_rank")).exportResult)
+    dataManager.get(g.box(
+      "Export edge attributes to Neo4j",
+      Map("url" -> server.getBoltUrl, "keys" -> "comment", "to_export" -> "dispersion")).exportResult)
+    val p = importBox("Import from Neo4j", Map("url" -> server.getBoltUrl)).project
+    assert(get(p.vertexAttributes("page_rank")).values.toSet ==
+      get(g.project.vertexAttributes("page_rank")).values.toSet)
+    assert(get(p.edgeAttributes("dispersion")).values.toSet ==
+      get(g.project.edgeAttributes("dispersion")).values.toSet)
+    server.stop()
+  }
+}

--- a/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
@@ -7,7 +7,15 @@ The relationships in Neo4j are identified by a key property (or properties).
 You must have a corresponding edge attribute in LynxKite by the same name.
 This will be used to find the right relationship to update in Neo4j.
 
-The properties of the Neo4j relationships will be updated with the exported edge attributes.
+The properties of the Neo4j relationships will be updated with the exported edge attributes
+using a Cypher query like this:
+
+    UNWIND $events as event
+    MATCH ()-[r:TYPE {`key`: event.`key`}]-()
+    SET r += event
+
+In the event of duplicate keys on either end this will update the properties of all the matching
+Neo4j relationships with the values from the last matching LynxKite edge.
 
 ====
 

--- a/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
@@ -1,0 +1,38 @@
+### Export edge attributes to Neo4j
+
+Exports edge attributes from a graph in LynxKite to a
+corresponding graph in https://neo4j.com/[Neo4j].
+
+The relationships in Neo4j are identified by a key property (or properties).
+You must have a corresponding edge attribute in LynxKite by the same name.
+This will be used to find the right relationship to update in Neo4j.
+
+The properties of the Neo4j relationships will be updated with the exported edge attributes.
+
+====
+
+[p-url]#Neo4j connection#::
+The Neo4j connection string of the form `bolt://localhost:7687`.
+
+[p-username]#Neo4j username#::
+Username for the connection.
+
+[p-password]#Neo4j password#::
+Password for the connection. It will be saved in the workspace and visible to anyone with
+access to the workspace.
+
+[p-version]#Export repetition ID#::
+LynxKite only re-computes outputs if parameters or inputs have changed.
+This is true for exports too. If you want to repeat a previous export, you can increase this
+export repetition ID parameter.
+
+[p-labels]#Relationship type#::
+Makes it possible to restrict the export to one relationship type in Neo4j.
+This is useful to make sure no other relationship type is accidentally affected.
+The format is as in Cypher: `:TYPE`. Leave empty to allow updating any node.
+
+[p-keys]#Attribute(s) to use as key#::
+Select the attribute (or attributes) to identify the Neo4j relationships by.
+The attribute name must match the property name in Neo4j.
+
+====

--- a/web/app/help/operations/export-graph-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-graph-to-neo4j.asciidoc
@@ -7,6 +7,28 @@ No existing data is modified in Neo4j.
 A `!LynxKite export timestamp` property is added to each new
 node and relationship in Neo4j. This helps clean up the export if needed.
 
+The Cypher query to export nodes is, depending on whether an attribute specifies the node labels:
+
+    UNWIND $events AS event
+    // Without node labels:
+    CREATE (n)
+    SET n += event
+    // With node labels taken from the "label" attribute:
+    CALL apoc.create.node(split(event.`label`, ','), event) YIELD node
+    RETURN 1
+
+The Cypher query to export relationships is, depending on whether an attribute specifies the
+relationship types:
+
+    UNWIND $events AS event
+    MATCH (src {`!LynxKite ID`: event.`!Source LynxKite ID`}), (dst {`!LynxKite ID`: event.`Destination LynxKite ID`})
+    // Without relationship types:
+    CREATE (src)-[r:EDGE]->(dst)
+    SET r += event
+    // With relationship types taken from the "type" attribute:
+    CALL apoc.create.relationship(src, event.`type`, event, dst) YIELD rel
+    RETURN 1
+
 ====
 
 [p-url]#Neo4j connection#::

--- a/web/app/help/operations/export-graph-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-graph-to-neo4j.asciidoc
@@ -1,0 +1,37 @@
+### Export graph to Neo4j
+
+Exports a graph from LynxKite to https://neo4j.com/[Neo4j].
+The whole graph will be copied to Neo4j with all attributes.
+No existing data is modified in Neo4j.
+
+A `!LynxKite export timestamp` property is added to each new
+node and relationship in Neo4j. This helps clean up the export if needed.
+
+====
+
+[p-url]#Neo4j connection#::
+The Neo4j connection string of the form `bolt://localhost:7687`.
+
+[p-username]#Neo4j username#::
+Username for the connection.
+
+[p-password]#Neo4j password#::
+Password for the connection. It will be saved in the workspace and visible to anyone with
+access to the workspace.
+
+[p-version]#Export repetition ID#::
+LynxKite only re-computes outputs if parameters or inputs have changed.
+This is true for exports too. If you want to repeat a previous export, you can increase this
+export repetition ID parameter.
+
+[p-node_labels]#Node labels#::
+A string vertex attribute that is a comma-separated list of labels to apply to the newly
+created nodes. Optional. You must have https://neo4j.com/developer/neo4j-apoc/[Neo4j APOC]
+installed on the Neo4j instance to use this.
+
+[p-relationship_type]#Attribute with relationship type#::
+A string edge attribute that specifies the relationship type for each newly created relationship.
+Optional. You must have https://neo4j.com/developer/neo4j-apoc/[Neo4j APOC]
+installed on the Neo4j instance to use this.
+
+====

--- a/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
@@ -7,7 +7,15 @@ The nodes in Neo4j are identified by a key property (or properties).
 You must have a corresponding vertex attribute in LynxKite by the same name.
 This will be used to find the right nodes to update in Neo4j.
 
-The properties of the Neo4j nodes will be updated with the exported vertex attributes.
+The properties of the Neo4j nodes will be updated with the exported vertex attributes using
+a Cypher query like this:
+
+    UNWIND $events as event
+    MATCH (n:Label1:Label2 {`key`: event.`key`})
+    SET n += event
+
+In the event of duplicate keys on either end this will update the properties of all the matching
+Neo4j nodes with the values from the last matching LynxKite vertex.
 
 ====
 

--- a/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
@@ -1,0 +1,38 @@
+### Export vertex attributes to Neo4j
+
+Exports vertex attributes from a graph in LynxKite to a
+corresponding graph in https://neo4j.com/[Neo4j].
+
+The nodes in Neo4j are identified by a key property (or properties).
+You must have a corresponding vertex attribute in LynxKite by the same name.
+This will be used to find the right nodes to update in Neo4j.
+
+The properties of the Neo4j nodes will be updated with the exported vertex attributes.
+
+====
+
+[p-url]#Neo4j connection#::
+The Neo4j connection string of the form `bolt://localhost:7687`.
+
+[p-username]#Neo4j username#::
+Username for the connection.
+
+[p-password]#Neo4j password#::
+Password for the connection. It will be saved in the workspace and visible to anyone with
+access to the workspace.
+
+[p-version]#Export repetition ID#::
+LynxKite only re-computes outputs if parameters or inputs have changed.
+This is true for exports too. If you want to repeat a previous export, you can increase this
+export repetition ID parameter.
+
+[p-labels]#Node labels#::
+Makes it possible to restrict the export to one label (or combination of labels) in Neo4j.
+This is useful to make sure no other node type is accidentally affected.
+The format is as in Cypher: `:Label1:Label2`. Leave empty to allow updating any node.
+
+[p-keys]#Attribute(s) to use as key#::
+Select the attribute (or attributes) to identify the Neo4j nodes by.
+The attribute name must match the property name in Neo4j.
+
+====

--- a/web/app/help/operations/index.asciidoc
+++ b/web/app/help/operations/index.asciidoc
@@ -283,6 +283,10 @@ include::discard-vertex-attributes.asciidoc[]
 
 include::embed-vertices.asciidoc[]
 
+include::export-edge-attributes-to-neo4j.asciidoc[]
+
+include::export-graph-to-neo4j.asciidoc[]
+
 include::export-to-avro.asciidoc[]
 
 include::export-to-csv.asciidoc[]
@@ -298,6 +302,8 @@ include::export-to-json.asciidoc[]
 include::export-to-orc.asciidoc[]
 
 include::export-to-parquet.asciidoc[]
+
+include::export-vertex-attributes-to-neo4j.asciidoc[]
 
 include::expose-internal-edge-id.asciidoc[]
 


### PR DESCRIPTION
This is part 1: exporting attributes for existing nodes.

There's an option to set `node.keys` and let them build the query. But if I use that, the label is a must. If I write the same query manually, I can leave it off. (http://5.9.211.195:8000/neo4j-spark-docs/1.0.0/writing.html#bookmark-write-node)

Open tasks:
- [x] Make sure this works if the keys are not defined everywhere.
- [x] Attribute export for edges.
- [ ] Edge export for existing nodes. (I don't think this is important.)
- [x] Export whole graph as new stuff.
- [x] Documentation.
- [x] Tests. (Maybe when the final Neo4j Spark Connector is released.)