### PR TITLE
Still log to rolling log files in Docker

### DIFF
--- a/conf/logger-docker.xml
+++ b/conf/logger-docker.xml
@@ -3,15 +3,29 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
-   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-     <target>System.err</target>
-     <encoder>
-         <!-- We should replace all occurrences of SECRET(...) in both message and exception.
-         But then logback does not realize that the exception was in fact logged, and attaches the
-         unfiltered version at the end. That's why we need the final nopex -->
-       <pattern>%.-1level%date %logger{0}:[%thread] %replace(%msg%n%xException){'SECRET\(.*\)','***'}%nopex</pattern>
-     </encoder>
-   </appender>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="com.lynxanalytics.biggraph.graph_util.DayBasedForcibleRollingPolicy">
+      <fileNamePattern>${KITE_LOG_DIR}/application-%d{yyyyMMdd_HHmmss}.log</fileNamePattern>
+      <maxHistory>5184000</maxHistory> <!-- 5184000 = 60 days, given in seconds -->
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+    <encoder>
+        <!-- We should replace all occurrences of SECRET(...) in both message and exception.
+        But then logback does not realize that the exception was in fact logged, and attaches the
+        unfiltered version at the end. That's why we need the final nopex -->
+      <pattern>%.-1level%date %logger{0}:[%thread] %replace(%msg%n%xException){'SECRET\(.*\)','***'}%nopex</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+        <!-- We should replace all occurrences of SECRET(...) in both message and exception.
+        But then logback does not realize that the exception was in fact logged, and attaches the
+        unfiltered version at the end. That's why we need the final nopex -->
+      <pattern>%.-1level%date %logger{0}:[%thread] %replace(%msg%n%xException){'SECRET\(.*\)','***'}%nopex</pattern>
+    </encoder>
+  </appender>
 
   <logger name="play" level="INFO" />
   <logger name="application" level="INFO" />
@@ -19,6 +33,7 @@
   <logger name="LynxKite" level="INFO" />
 
   <root level="ERROR">
+    <appender-ref ref="FILE" />
     <appender-ref ref="STDERR" />
   </root>
 


### PR DESCRIPTION
Resolves #126. The logs are accessible from `/logs` in a browser.