### PR TITLE
Small UI fixes

### DIFF
--- a/web/app/scripts/splash/entry-selector.js
+++ b/web/app/scripts/splash/entry-selector.js
@@ -21,7 +21,7 @@ angular.module('biggraph').directive('entrySelector',
             return;
           }
           // We don't need a reload for directory navigation, but we track the path in the URL.
-          const url = '/dir/' + p;
+          const url = '/dir/' + encodeURIComponent(p);
           if (url !== $location.url()) {
             util.skipReload();
             $location.url(url);

--- a/web/app/styles/operation-selector.css
+++ b/web/app/styles/operation-selector.css
@@ -1,6 +1,7 @@
 .operation-selector {
   margin-left: -35px;
-  float: left;
+  position: absolute;
+  right: 0;
 }
 
 .operation-selector .box {

--- a/web/app/styles/workspace.css
+++ b/web/app/styles/workspace.css
@@ -7,10 +7,14 @@
 #workspace-header {
   background: #002a4c; /* Brand color. */
   color: white;
-  min-height: 60px;
+  height: 60px;
+  flex-wrap: nowrap;
 }
 #workspace-header .flat-toolbar-title {
   padding: 5px 10px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 span#workspace-name {


### PR DESCRIPTION
Fixes #153. Fixes #154.

The flickering was caused by the CSS transition of the `transform` on box hover. If you make the transition longer (I used 1000 seconds) you can inspect where the category selector goes off to. It's somewhere off-screen. Interestingly the magnifying glass icon stays in place.

I'm not sure how this selector was positioned in the first place. It had a `float: left` property. But it's on the right? Anyway, I changed it to `position: absolute; right: 0;` which makes more sense and also works even during the transition.

As I was testing to make sure this works with all sorts of window sizes, I notice that a long workspace name subtly breaks a few things and looks ugly. I've changed it so this never happens. We rather truncate the workspace name with a "..." at the end.

The other thing driving me crazy was that clicking on something to open it from the directory browser just didn't work. Turns out this has been the case since 4.0.0 (https://github.com/lynxkite/lynxkite/commit/f2a445032f10a789e8b2bd88c7ad0cff329d8230) but it only affects directories that have spaces in the name. (Like we're on Windows 95! :smile:)

We don't want to reload the directory browser when it's just changing directories. So the linked commit added `skipReload()` which will skip the controller reload on the next URL change. We call `skipReload()` before changing the URL to a different directory.

Emphasis on _"different"_: We also call it when changing from `Foo bar` to `Foo%20bar`. But that does not actually trigger a URL change. So we will skip the controller reload on the URL change _after that!_ E.g. when we are supposed to load the workspace.

It's just terrible. For now I've just added a simple local fix. I guess there is a better way to do this, but I can't spend more time on it now.