### PR TITLE
[WIP] Add SpanningEdgeCentrality

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/GraphComputationOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/GraphComputationOperations.scala
@@ -92,6 +92,21 @@ class GraphComputationOperations(env: SparkFreeEnvironment) extends ProjectOpera
     }
   })
 
+  register("Compute spanning edge centrality")(new ProjectTransformation(_) {
+    params ++= List(
+      Param("name", "Attribute name", defaultValue = "centrality"),
+      Param("tolerance", "Tolerance of estimation", defaultValue = "0.1"))
+    def enabled = project.hasEdgeBundle
+    def apply() = {
+      val name = params("name")
+      assert(name.nonEmpty, "Please set an attribute name.")
+      val centrality = graph_operations.NetworKitComputeDoubleEdgeAttribute.run(
+        "SpanningEdgeCentrality", project.edgeBundle,
+        Map("tolerance" -> params("tolerance").toDouble))
+      project.newEdgeAttribute(name, centrality, help)
+    }
+  })
+
   register("Find k-core decomposition")(new ProjectTransformation(_) {
     params ++= List(Param("name", "Attribute name", defaultValue = "core"))
     def enabled = project.hasEdgeBundle

--- a/sphynx/lynxkite-sphynx/networkit_compute_double_edge_attribute.go
+++ b/sphynx/lynxkite-sphynx/networkit_compute_double_edge_attribute.go
@@ -44,6 +44,11 @@ func init() {
 						result.Set(i, math.NaN())
 					}
 				}
+			case "SpanningEdgeCentrality":
+				c := networkit.NewSpanningEdgeCentrality(g, o.Double("tolerance"))
+				defer networkit.DeleteSpanningEdgeCentrality(c)
+				c.Run()
+				result = c.Scores()
 			}
 			// The NetworKit edge IDs don't correspond to the Sphynx edge IDs.
 			// We build a map to match them up by the src/dst vertex IDs.

--- a/sphynx/lynxkite-sphynx/networkit_compute_double_edge_attribute.go
+++ b/sphynx/lynxkite-sphynx/networkit_compute_double_edge_attribute.go
@@ -47,7 +47,11 @@ func init() {
 			case "SpanningEdgeCentrality":
 				c := networkit.NewSpanningEdgeCentrality(g, o.Double("tolerance"))
 				defer networkit.DeleteSpanningEdgeCentrality(c)
-				c.Run()
+				if o.Double("tolerance") == 0 {
+					c.Run()
+				} else {
+					c.RunApproximation()
+				}
 				result = c.Scores()
 			}
 			// The NetworKit edge IDs don't correspond to the Sphynx edge IDs.

--- a/sphynx/networkit/networkit.swigcxx
+++ b/sphynx/networkit/networkit.swigcxx
@@ -13,6 +13,7 @@
 #include <networkit/centrality/KPathCentrality.hpp>
 #include <networkit/centrality/LaplacianCentrality.hpp>
 #include <networkit/centrality/Sfigality.hpp>
+#include <networkit/centrality/SpanningEdgeCentrality.hpp>
 #include <networkit/correlation/Assortativity.hpp>
 #include <networkit/distance/Diameter.hpp>
 #include <networkit/distance/EffectiveDiameter.hpp>
@@ -159,6 +160,7 @@ public:
 %include "include/networkit/centrality/KPathCentrality.hpp"
 %include "include/networkit/centrality/LaplacianCentrality.hpp"
 %include "include/networkit/centrality/Sfigality.hpp"
+%include "include/networkit/centrality/SpanningEdgeCentrality.hpp"
 %include "include/networkit/correlation/Assortativity.hpp"
 %include "include/networkit/distance/Diameter.hpp"
 %include "include/networkit/distance/EffectiveDiameter.hpp"


### PR DESCRIPTION
For @hampet97's thesis work. And it's nice anyway.

![image](https://user-images.githubusercontent.com/1268018/116526126-8d7bc300-a8d9-11eb-88b9-c5f2baee73de.png)

TODO: Test and docs.

For vertex centrality we have a single box. Do you think we should have a single box for edge centrality or separate boxes? With a single algorithm it feels weird to have a drop-down, but maybe better for the future?