### PR TITLE
Compatibility fix for Set parameters

### DIFF
--- a/app/com/lynxanalytics/biggraph/graph_api/JsonMigration.scala
+++ b/app/com/lynxanalytics/biggraph/graph_api/JsonMigration.scala
@@ -43,6 +43,13 @@ object JsonMigration {
       className(graph_operations.DoubleGE) -> 1,
       className(graph_operations.DoubleGT) -> 1,
       className(graph_operations.EnhancedExampleGraph) -> 1,
+      // These have Set-typed parameters that have unreliable JSON representations across versions.
+      // In LynxKite 4.3.0 we switched to saving them as sorted arrays.
+      className(graph_operations.CollectAttribute) -> 1,
+      className(graph_operations.EdgesForVerticesFromEdgesAndNeighbors) -> 1,
+      className(graph_operations.OneOf) -> 1,
+      className(graph_operations.RestrictAttributeToIds) -> 1,
+      className(graph_operations.SampledView) -> 1,
     )
       .withDefaultValue(0),
     Map(
@@ -53,6 +60,11 @@ object JsonMigration {
       (className(graph_operations.DoubleGE), 0) -> identity,
       (className(graph_operations.DoubleGT), 0) -> identity,
       (className(graph_operations.EnhancedExampleGraph), 0) -> identity,
+      (className(graph_operations.CollectAttribute), 0) -> identity,
+      (className(graph_operations.EdgesForVerticesFromEdgesAndNeighbors), 0) -> identity,
+      (className(graph_operations.OneOf), 0) -> identity,
+      (className(graph_operations.RestrictAttributeToIds), 0) -> identity,
+      (className(graph_operations.SampledView), 0) -> identity,
     ))
 }
 import JsonMigration._

--- a/app/com/lynxanalytics/biggraph/graph_operations/AttributeFilters.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/AttributeFilters.scala
@@ -186,7 +186,7 @@ object OneOf extends FromJson[OneOf[_]] {
 }
 case class OneOf[T](options: Set[T]) extends Filter[T] {
   def matches(value: T) = options.contains(value)
-  override def toJson = Json.obj("options" -> options.toSeq.map(TypedJson(_)))
+  override def toJson = Json.obj("options" -> options.toSeq.map(TypedJson(_)).sortBy(_.toString))
 }
 
 object Exists extends FromJson[Exists[_]] {

--- a/app/com/lynxanalytics/biggraph/graph_operations/CollectAttribute.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/CollectAttribute.scala
@@ -20,7 +20,7 @@ case class CollectAttribute[T](
     extends SparkOperation[VertexAttributeInput[T], Output[T]] {
   @transient override lazy val inputs = new VertexAttributeInput[T]
   def outputMeta(instance: MetaGraphOperationInstance) = new Output()(instance, inputs)
-  override def toJson = Json.obj("idSet" -> idSet)
+  override def toJson = Json.obj("idSet" -> idSet.toSeq.sorted)
 
   def execute(inputDatas: DataSet, o: Output[T], output: OutputBuilder, rc: RuntimeContext) = {
     implicit val id = inputDatas

--- a/app/com/lynxanalytics/biggraph/graph_operations/RestrictedAttribute.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/RestrictedAttribute.scala
@@ -29,7 +29,7 @@ case class RestrictAttributeToIds[T](vertexIdSet: Set[ID])
 
   def outputMeta(instance: MetaGraphOperationInstance) =
     new Output()(instance, inputs)
-  override def toJson = Json.obj("vertexIdSet" -> vertexIdSet)
+  override def toJson = Json.obj("vertexIdSet" -> vertexIdSet.toSeq.sorted)
 
   def execute(
       inputDatas: DataSet,

--- a/app/com/lynxanalytics/biggraph/graph_operations/SampledView.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/SampledView.scala
@@ -26,7 +26,7 @@ case class SampledView(
   @transient override lazy val inputs = new Input
 
   def outputMeta(instance: MetaGraphOperationInstance) = new Output()(instance)
-  override def toJson = Json.obj("idSet" -> idSet)
+  override def toJson = Json.obj("idSet" -> idSet.toSeq.sorted)
 
   def execute(inputDatas: DataSet, o: Output, output: OutputBuilder, rc: RuntimeContext) = {
     implicit val id = inputDatas

--- a/app/com/lynxanalytics/biggraph/graph_operations/TripletAttributes.scala
+++ b/app/com/lynxanalytics/biggraph/graph_operations/TripletAttributes.scala
@@ -264,8 +264,8 @@ case class EdgesForVerticesFromEdgesAndNeighbors(
   }
 
   override def toJson = Json.obj(
-    "srcIdSet" -> srcIdSet,
-    "dstIdSet" -> dstIdSet,
+    "srcIdSet" -> srcIdSet.toSeq.sorted,
+    "dstIdSet" -> dstIdSet.map(_.toSeq.sorted),
     "maxNumEdges" -> maxNumEdges)
 
   def execute(


### PR DESCRIPTION
Sets are serialized to JSON as arrays in arbitrary order. The arbitrary order changed due to some upgrade in #178. This caused a GUID mismatch when loading operations that have Set parameters. There are not many such operations and they are mostly in visualizations. So I just increased the JSON version. This will create a migration and these operations will have to be recomputed.

I've also changed the JSON output to use sorted arrays so we won't hit this issue again.