### PR TITLE
Faster workspace execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please add changes to "master", preferably ordered by their significance. (Most 
 ### master
 
 - Upgraded to PyTorch Geometric (PyG) 2.0.1. [#206](https://github.com/lynxkite/lynxkite/pull/206)
+- The workspace interface is much faster now. [#220](https://github.com/lynxkite/lynxkite/pull/220)
 
 ### 4.3.0
 

--- a/app/com/lynxanalytics/biggraph/controllers/Operation.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/Operation.scala
@@ -304,6 +304,7 @@ abstract class OperationRepository(env: SparkFreeEnvironment) {
   def getBoxMetadata(id: String) = getBox(id)._1
 
   def atomicOperationIds = atomicOperations.keys.toSeq.sorted
+  def isCustom(id: String) = !atomicOperations.contains(id)
 
   private def listFolder(user: serving.User, path: String): Seq[String] = {
     val entry = DirectoryEntry.fromName(path)

--- a/app/com/lynxanalytics/biggraph/controllers/Workspace.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/Workspace.scala
@@ -269,15 +269,18 @@ case class Box(
   def execute(
       ctx: WorkspaceExecutionContext,
       inputStates: Map[String, BoxOutputState]): Map[BoxOutput, BoxOutputState] = {
-    ctx.ops.metaGraphManager.boxCache.getOrElseUpdate(
-      id,
-      operationId,
-      parameters,
-      inputStates,
-      parametricParameters,
-      ctx.workspaceParameters) {
-      val op = getOperation(ctx, inputStates)
-      op.getOutputs
+    if (ctx.ops.isCustom(operationId)) {
+      getOperation(ctx, inputStates).getOutputs
+    } else {
+      ctx.ops.metaGraphManager.boxCache.getOrElseUpdate(
+        id,
+        operationId,
+        parameters,
+        inputStates,
+        parametricParameters,
+        ctx.workspaceParameters) {
+        getOperation(ctx, inputStates).getOutputs
+      }
     }
   }
 

--- a/app/com/lynxanalytics/biggraph/controllers/Workspace.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/Workspace.scala
@@ -217,10 +217,11 @@ class BoxCache(maxSize: Int)
       operationId: String,
       parameters: Map[String, String],
       inputs: Map[String, BoxOutputState],
-      parametricParameters: Map[String, String])(
+      parametricParameters: Map[String, String],
+      workspaceParameters: Map[String, String])(
       outputs: => Map[BoxOutput, BoxOutputState],
   ): Map[BoxOutput, BoxOutputState] = synchronized {
-    val k = key(operationId, parameters, inputs, parametricParameters)
+    val k = key(operationId, parameters, inputs, parametricParameters, workspaceParameters)
     if (this.containsKey(k)) {
       val v = this.get(k)
       v.map { case (k, v) => BoxOutput(boxId, k) -> v }
@@ -234,11 +235,13 @@ class BoxCache(maxSize: Int)
       operationId: String,
       parameters: Map[String, String],
       inputs: Map[String, BoxOutputState],
-      parametricParameters: Map[String, String]): String = {
+      parametricParameters: Map[String, String],
+      workspaceParameters: Map[String, String]): String = {
     val s: Seq[String] = Seq(operationId) ++
       parameters.flatMap { case (k, v) => Seq(k, v) } ++
       inputs.flatMap { case (k, v) => Seq(k, v.gUID.toString) } ++
-      parametricParameters.flatMap { case (k, v) => Seq(k, v) }
+      parametricParameters.flatMap { case (k, v) => Seq(k, v) } ++
+      workspaceParameters.flatMap { case (k, v) => Seq(k, v) }
     s.mkString("##")
   }
 }
@@ -271,7 +274,8 @@ case class Box(
       operationId,
       parameters,
       inputStates,
-      parametricParameters) {
+      parametricParameters,
+      ctx.workspaceParameters) {
       val op = getOperation(ctx, inputStates)
       op.getOutputs
     }

--- a/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
@@ -398,7 +398,7 @@ class WorkflowOperations(env: SparkFreeEnvironment) extends ProjectOperations(en
         def enabled = FEStatus.enabled
         def defaultTableName = {
           val first = inputNames.head
-          val state = context.inputs(first)
+          val state = context.inputs(inputs.head)
           val name =
             if (state.isProject) {
               if (inputNames.length == 1) "vertices"

--- a/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
@@ -390,7 +390,7 @@ class WorkflowOperations(env: SparkFreeEnvironment) extends ProjectOperations(en
         params += Code(
           "sql",
           "SQL",
-          defaultValue = s"select * from $defaultTableName limit 10\n",
+          defaultValue = s"select * from $defaultTableName\n",
           language = "sql",
           enableTableBrowser = true)
         params += Choice("persist", "Persist result", options = FEOption.noyes)

--- a/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
@@ -393,7 +393,7 @@ class WorkflowOperations(env: SparkFreeEnvironment) extends ProjectOperations(en
           defaultValue = s"select * from $defaultTableName limit 10\n",
           language = "sql",
           enableTableBrowser = true)
-        params += Choice("persist", "Persist result", options = FEOption.yesno)
+        params += Choice("persist", "Persist result", options = FEOption.noyes)
         override def summary = params("summary")
         def enabled = FEStatus.enabled
         def defaultTableName = {

--- a/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/WorkflowOperations.scala
@@ -397,10 +397,13 @@ class WorkflowOperations(env: SparkFreeEnvironment) extends ProjectOperations(en
         override def summary = params("summary")
         def enabled = FEStatus.enabled
         def defaultTableName = {
-          val tableNames = this.getInputTables(renaming).keySet.toList.sorted
-          val name = Seq("vertices", inputNames.head, inputNames.head + ".vertices")
-            .find(tableNames.contains(_))
-            .getOrElse(tableNames.head)
+          val first = inputNames.head
+          val state = context.inputs(first)
+          val name =
+            if (state.isProject) {
+              if (inputNames.length == 1) "vertices"
+              else first + ".vertices"
+            } else first
           val simple = "[a-zA-Z0-9]*".r
           name match {
             case simple() => name

--- a/app/com/lynxanalytics/biggraph/graph_api/MetaGraphManager.scala
+++ b/app/com/lynxanalytics/biggraph/graph_api/MetaGraphManager.scala
@@ -16,12 +16,15 @@ import scala.reflect.runtime.universe.TypeTag
 import com.lynxanalytics.biggraph.{bigGraphLogger => log}
 import com.lynxanalytics.biggraph.controllers.CheckpointRepository
 import com.lynxanalytics.biggraph.controllers.DirectoryEntry
+import com.lynxanalytics.biggraph.controllers.BoxCache
 import com.lynxanalytics.biggraph.controllers.Workspace
+import com.lynxanalytics.biggraph.graph_util.LoggedEnvironment
 import com.lynxanalytics.biggraph.graph_util.Timestamp
 
 class MetaGraphManager(val repositoryPath: String) {
   val checkpointRepo = MetaGraphManager.getCheckpointRepo(repositoryPath)
   val repositoryRoot = new File(repositoryPath).getParent()
+  val boxCache = new BoxCache(LoggedEnvironment.envOrElse("KITE_BOX_CACHE_SIZE", "100000").toInt)
 
   def apply[IS <: InputSignatureProvider, OMDS <: MetaDataSetProvider](
       operation: TypedMetaGraphOp[IS, OMDS],

--- a/app/com/lynxanalytics/biggraph/spark_util/BigGraphSparkContext.scala
+++ b/app/com/lynxanalytics/biggraph/spark_util/BigGraphSparkContext.scala
@@ -374,6 +374,9 @@ class BigGraphKryoRegistrator extends KryoRegistrator {
     kryo.register(Class.forName("org.apache.spark.sql.types.Decimal$DecimalIsFractional$"))
     kryo.register(Class.forName("org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTaskResult"))
     kryo.register(Class.forName("org.apache.spark.sql.execution.columnar.DefaultCachedBatch"))
+    kryo.register(Class.forName("scala.math.Ordering$Reverse"))
+    kryo.register(Class.forName("org.apache.spark.sql.catalyst.InternalRow$"))
+    kryo.register(Class.forName("org.apache.spark.sql.catalyst.expressions.NullsFirst$"))
 
     // Add new stuff just above this line! Thanks.
     // Adding Foo$mcXXX$sp? It is a type specialization. Register the decoded type instead!

--- a/dependency-licenses/javascript.md
+++ b/dependency-licenses/javascript.md
@@ -499,7 +499,7 @@
 │  ├─ flagged-respawn@1.0.1
 │  ├─ flat-cache@2.0.1
 │  ├─ flush-write-stream@1.1.1
-│  ├─ follow-redirects@1.14.1
+│  ├─ follow-redirects@1.14.7
 │  ├─ for-in@1.0.2
 │  ├─ for-own@1.0.0
 │  ├─ form-data@2.3.3
@@ -659,7 +659,7 @@
 │  ├─ map-cache@0.2.2
 │  ├─ map-stream@0.0.7
 │  ├─ map-visit@1.0.0
-│  ├─ markdown-it@12.0.6
+│  ├─ markdown-it@12.3.2
 │  ├─ matchdep@2.0.0
 │  ├─ mdurl@1.0.1
 │  ├─ merge-stream@2.0.0
@@ -680,7 +680,7 @@
 │  ├─ ms@2.1.3
 │  ├─ mute-stdout@1.0.1
 │  ├─ nan@2.14.2
-│  ├─ nanoid@3.1.23
+│  ├─ nanoid@3.2.0
 │  ├─ nanomatch@1.2.13
 │  ├─ natural-compare@1.4.0
 │  ├─ negotiator@0.6.2


### PR DESCRIPTION
I'm addressing multiple issues here:
- Persistent outputs are slower because they write to disk. It's just a bad default.
- The default LIMIT is annoying and no longer necessary if we don't persist the table. (#151)
- Each SQL box created 6 VertexToEdgeAttribute operations per input vertex attribute. With 100 attributes and 20 SQL boxes this was 12,000 operations on every `setAndGetWorkspace` request. That takes around 3 seconds. That's long enough that you start clicking on more things, creating an increasing backlog of requests. In my test I got 20–30 second response times easily.

![Screenshot 2022-02-01 at 19 31 43](https://user-images.githubusercontent.com/1268018/152153351-2eb64965-25e2-42ed-a870-fc52a211ae69.png)

For the third issue 4 of the 6 VertexToEdgeAttribute operations were unnecessarily caused by the `defaultTableName` code. That's easy to fix. But the other two are unavoidable if we execute the box.

So I've added a "BoxCache" to avoid unnecessary box executions. This is a huge improvement. Even if you only moved a box, we used to execute all the boxes in the workspace. But with the cache we don't execute anything and it's super fast. When you change something, we only execute that one box.

I went with this universal solution rather than try to improve the SQL box code, because it's not the only box that scales linearly with the number of attributes. E.g. a filter box will pull over all attributes. It's a bit faster than the SQL box, but I still saw 1–2 second latencies with 100 attributes and 20 filter boxes. The cache fixes this for all boxes.

Do you see any potential issues with it?
