### PR TITLE
Fix filesystem-dependent issue with HybridBundle storage

### DIFF
--- a/app/com/lynxanalytics/biggraph/graph_api/io/EntityIO.scala
+++ b/app/com/lynxanalytics/biggraph/graph_api/io/EntityIO.scala
@@ -594,7 +594,7 @@ class HybridBundleIO(entity: HybridBundle, context: IOContext)
         (dir / "large_keys_rdd")
           .saveEntityRDD(hybridRDD.largeKeysRDD.get, valueTypeTag)._1
       } else { 0L }
-    (dir / Success).create()
+    (dir / Success).createEmpty
     (linesSmallKeys + linesLargeKeys, "hybrid")
   }
 


### PR DESCRIPTION
Unclosed files may or may not get created. So on some filesystems, like GCS we end up with a missing _SUCCESS file here.