### PR TITLE
Fix for "unsupported type" bug

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/ScalarOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ScalarOperations.scala
@@ -166,11 +166,13 @@ class ScalarOperations(env: SparkFreeEnvironment) extends ProjectOperations(env)
       val expr = params("expr")
       s"Derive graph attribute: $name = $expr"
     }
-    def apply() = {
+    def apply(): Unit = {
+      val output = params("output")
       val expr = params("expr")
+      if (output.isEmpty || expr.isEmpty) return
       val namedScalars = ScalaUtilities.collectIdentifiers[Scalar[_]](project.scalars, expr)
       val result = graph_operations.DeriveScalaScalar.deriveAndInferReturnType(expr, namedScalars)
-      project.newScalar(params("output"), result, expr + help)
+      project.newScalar(output, result, expr + help)
     }
   })
 }

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
@@ -138,4 +138,18 @@ df['age_4']: float = df.age_2 ** 2
       List(6250000.0, "Bob"),
       List(16.0, "Isolated Joe")))
   }
+
+  test("unsupported types are fine if you don't use them", SphynxOnly) {
+    val p = box("Create example graph")
+      .box("Train linear regression model", Map("features" -> "age"))
+      .box("Compute in Python", Map("code" -> "vs['y']: str = vs.name"))
+      .project
+    assert(
+      get(p.vertexAttributes("y").runtimeSafeCast[String]) ==
+        Map(
+          0 -> "Adam",
+          1 -> "Eve",
+          2 -> "Bob",
+          3 -> "Isolated Joe"))
+  }
 }


### PR DESCRIPTION
You get this error if you have an unsupported type (e.g. trained model) even when you are not passing it to a Python box as input. This change postpones the type serialization a bit so we only do it for the actual inputs.