### PR TITLE
Fix _SUCCESS file creation in SphynxDomain

### DIFF
--- a/app/com/lynxanalytics/biggraph/graph_api/SphynxDomain.scala
+++ b/app/com/lynxanalytics/biggraph/graph_api/SphynxDomain.scala
@@ -217,7 +217,7 @@ abstract class UnorderedSphynxDisk(host: String, port: Int, certDir: String)
             val fname = (dst.dataDir / s.gUID.toString / "serialized_data")
             val successFile = (dst.dataDir / s.gUID.toString / "_SUCCESS")
             fname.createFromStrings(jsonString)
-            successFile.create()
+            successFile.createEmpty()
           case dst: UnorderedSphynxLocalDisk =>
             val fname = s"${dst.getGUIDPath(e)}/serialized_data"
             val successFile = s"${dst.getGUIDPath(e)}/_SUCCESS"
@@ -334,7 +334,7 @@ class UnorderedSphynxSparkDisk(host: String, port: Int, certDir: String, val dat
           } catch {
             case t: Throwable => throw new AssertionError(s"Failed to relocate $e from $source", t)
           }
-          (dstDir / "_SUCCESS").create()
+          (dstDir / "_SUCCESS").createEmpty()
         })
       case source: SparkDomain => relocateFromSpark(e, source)
     }

--- a/app/com/lynxanalytics/biggraph/graph_util/HadoopFile.scala
+++ b/app/com/lynxanalytics/biggraph/graph_util/HadoopFile.scala
@@ -161,6 +161,7 @@ class HadoopFile private (
   def open() = fs.open(path)
   // The caller is responsible for calling close().
   def create() = fs.create(path)
+  def createEmpty() = create().close()
   def exists() = fs.exists(path)
   private def reader() = new BufferedReader(new InputStreamReader(open, "utf-8"))
   def readAsString() = {


### PR DESCRIPTION
Sorry, I added a call to `createEmpty` in #224 but we don't even have `createEmpty`. This was added on a private repo in October and I forgot to upstream it. This should do some good for the tests...