### PR TITLE
Strip slashes from directory settings, simplify code

### DIFF
--- a/tools/call_spark_submit.sh
+++ b/tools/call_spark_submit.sh
@@ -103,8 +103,6 @@ final_java_opts="${final_java_opts/user.dir=\/\//user.dir=\/}"
 # Cannot do this earlier, as the wrapping script is written in a -e hostile way. :(
 set -eo pipefail
 
-export REPOSITORY_MODE="static<$KITE_META_DIR,$KITE_DATA_DIR,$KITE_EPHEMERAL_DATA_DIR>"
-
 if [ -z "${NUM_CORES_PER_EXECUTOR}" ]; then
   >&2 echo "Please define NUM_CORES_PER_EXECUTOR in the kite config file ${KITE_SITE_CONFIG}."
   exit 1


### PR DESCRIPTION
A bit of [archeology](https://github.com/lynxkite/lynxkite/commit/6424509ff77f3c3a138d9629e21bc3fb582714d2) tells me this `REPOSITORY_MODE` setting served a purpose 8 years ago. Now I'm not even sure `RepositoryDirs` is needed now — we could pick up `KITE_DATA_DIR` when the domain is creating, like how the Sphynx directory settings are picked up. I'm leaving that alone though.