### PR TITLE
Python API for interfacing with PySpark DataFrames

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -40,3 +40,5 @@ dependencies:
 - requests
 - typed-ast
 - types-requests
+# For Python tests.
+- pyspark==3.2.1

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -984,7 +984,7 @@ class State:
   def get_progress(self):
     '''Returns progress info about the state.'''
     state_id = self._get_state_id()
-    progress = lk._ask('/ajax/long-poll', dict(syncedUntil=0, stateIds=[state_id]))
+    progress = self.box.lk._ask('/ajax/long-poll', dict(syncedUntil=0, stateIds=[state_id]))
     return progress.progress.__dict__[state_id]
 
   def run_export(self) -> str:
@@ -993,6 +993,7 @@ class State:
     Returns the prefixed path of the exported file. This method is deprecated,
     only used in tests, where we need the export path.
     '''
+    lk = self.box.lk
     state_id = self._get_state_id()
     export = lk.get_export_result(state_id)
     if export.result.computeProgress != 1:
@@ -1011,7 +1012,7 @@ class State:
 
   def save_snapshot(self, path: str) -> None:
     '''Save this state as a snapshot under path.'''
-    lk.save_snapshot(path, self._get_state_id())
+    self.box.lk.save_snapshot(path, self._get_state_id())
 
   def save_to_sequence(self, tss, date: datetime.datetime) -> None:
     '''Save this state to the ``tss`` TableSnapshotSequence with ``date`` as
@@ -1019,8 +1020,7 @@ class State:
     tss.save_to_sequence(self._get_state_id(), date)
 
   def _get_state_id(self):
-    lk = self.box.lk
-    return lk.get_state_id(self)
+    return self.box.lk.get_state_id(self)
 
 
 class Placeholder:

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -843,6 +843,13 @@ class LynxKite:
       df.to_parquet(f.name, **kwargs)
       return self.uploadParquetNow(f.read())
 
+  def from_spark(self, df):
+    """Converts a Spark DataFrame to a LynxKite table."""
+    filename = 'DATA$/python-imports/' + datetime.datetime.now().strftime('%Y-%d-%m_%H%M%S.%f')
+    resolved = self.get_prefixed_path(filename).resolved
+    df.write.parquet(resolved)
+    return self.importParquetNow(filename=filename)
+
   def set_executors(self, count):
     return self._send('/remote/setExecutors', {'count': count})
 
@@ -954,22 +961,27 @@ class State:
     data = [[get(c, t) for (c, t) in zip(r, types)] for r in table.data]
     return pandas.DataFrame(data, columns=header)
 
+  def spark(self, spark):
+    '''Takes a SparkSession as the argument and returns the table as a Spark DataFrame.'''
+    guid = self._get_state_id()  # The TableOutputState ID is the table GUID.
+    path = self.box.lk.get_prefixed_path('DATA$/tables/' + guid)
+    return spark.read.parquet(path.resolved)
+
   def columns(self):
     '''Returns a list of columns if this state is a table.'''
     return list(self.df(0).columns)
 
   def get_table_data(self, limit: int = -1) -> types.SimpleNamespace:
     '''Returns the "raw" table data if this state is a table.'''
-    return self.box.lk.get_table_data(self.box.lk.get_state_id(self), limit)
+    return self.box.lk.get_table_data(self._get_state_id(), limit)
 
   def get_graph(self) -> types.SimpleNamespace:
     '''Returns the graph metadata if this state is a graph.'''
-    return self.box.lk.get_graph(self.box.lk.get_state_id(self))
+    return self.box.lk.get_graph(self._get_state_id())
 
   def get_progress(self):
     '''Returns progress info about the state.'''
-    lk = self.box.lk
-    state_id = lk.get_state_id(self)
+    state_id = self._get_state_id()
     progress = lk._ask('/ajax/long-poll', dict(syncedUntil=0, stateIds=[state_id]))
     return progress.progress.__dict__[state_id]
 
@@ -979,8 +991,7 @@ class State:
     Returns the prefixed path of the exported file. This method is deprecated,
     only used in tests, where we need the export path.
     '''
-    lk = self.box.lk
-    state_id = lk.get_state_id(self)
+    state_id = self._get_state_id()
     export = lk.get_export_result(state_id)
     if export.result.computeProgress != 1:
       scalar = lk.get_graph_attribute(export.result.id)
@@ -998,16 +1009,16 @@ class State:
 
   def save_snapshot(self, path: str) -> None:
     '''Save this state as a snapshot under path.'''
-    lk = self.box.lk
-    state_id = lk.get_state_id(self)
-    lk.save_snapshot(path, state_id)
+    lk.save_snapshot(path, self._get_state_id())
 
   def save_to_sequence(self, tss, date: datetime.datetime) -> None:
     '''Save this state to the ``tss`` TableSnapshotSequence with ``date`` as
     the date of the snapshot.'''
+    tss.save_to_sequence(self._get_state_id(), date)
+
+  def _get_state_id(self):
     lk = self.box.lk
-    state_id = lk.get_state_id(self)
-    tss.save_to_sequence(state_id, date)
+    return lk.get_state_id(self)
 
 
 class Placeholder:

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -963,8 +963,10 @@ class State:
 
   def spark(self, spark):
     '''Takes a SparkSession as the argument and returns the table as a Spark DataFrame.'''
-    guid = self._get_state_id()  # The TableOutputState ID is the table GUID.
-    path = self.box.lk.get_prefixed_path('DATA$/tables/' + guid)
+    t = self.persist()
+    t.compute()
+    guid = t._get_state_id()  # The TableOutputState ID is the table GUID.
+    path = t.box.lk.get_prefixed_path('DATA$/tables/' + guid)
     return spark.read.parquet(path.resolved)
 
   def columns(self):

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -2008,11 +2008,3 @@ def _json_encode(obj):
 def to_simple_dicts(obj):
   '''Converts a SimpleNamespace structure (as returned from LynxKite requests) into simple dicts.'''
   return json.loads(json.dumps(obj, default=_json_encode))
-
-
-class PizzaBox(LynxKite):
-
-  def __init__(self):
-    super().__init__(address='https://pizzabox.lynxanalytics.com/')
-    assert self.oauth_token() or self.signed_token(), \
-        'Please set LYNXKITE_OAUTH_TOKEN or LYNXKITE_SIGNED_TOKEN.'

--- a/python/remote_api/tests/test_external_computation.py
+++ b/python/remote_api/tests/test_external_computation.py
@@ -57,10 +57,11 @@ class TestExternalComputation(unittest.TestCase):
     eg = lk.createExampleGraph().sql('select * from vertices')
     t = stats(eg)
     t.trigger()
-    # Column order can be different
-    actual = t.sql('select * from input').df().sort_index(axis=1)
-    expected = pd.DataFrame({'gender': ['Female', 'Male'], 'count': [1.0, 3.0]}).sort_index(axis=1)
-    self.assertTrue(actual.equals(expected))
+    actual = t.sql('select gender, count from input').df()
+    self.assertEquals(len(actual), 2)
+    d = dict(actual.values)
+    self.assertEquals(d['Male'], 3)
+    self.assertEquals(d['Female'], 1)
 
   def test_filename(self):
     lk = lynx.kite.LynxKite()

--- a/python/remote_api/tests/test_spark_conversion.py
+++ b/python/remote_api/tests/test_spark_conversion.py
@@ -1,0 +1,34 @@
+import unittest
+import lynx.kite
+from pyspark.sql import Row, SparkSession
+
+lk = lynx.kite.LynxKite()
+spark = SparkSession.builder.getOrCreate()
+
+
+class TestSparkConversion(unittest.TestCase):
+
+  def test_spark_to_lynxkite(self):
+    people_df = spark.createDataFrame([
+      Row(name='Adam', age=23),
+      Row(name='Eve', age=34),
+      Row(name='Bob', age=45),
+    ])
+    relationships_df = spark.createDataFrame([
+      Row(a='Adam', b='Eve', weight=3),
+      Row(a='Bob', b='Eve', weight=4),
+      Row(a='Eve', b='Adam', weight=5),
+    ])
+    g = lk.from_spark(people_df).useTableAsVertices()
+    g = lk.useTableAsEdges(
+      g,
+      lk.from_spark(relationships_df),
+      attr='name', src='a', dst='b')
+    self.assertEqual(3, g.sql('select count(*) from vertices').df().values[0][0])
+
+  def test_lynxkite_to_spark(self):
+    t = lk.createExampleGraph().sql('select name, age from vertices')
+    df = t.spark(spark)
+    self.assertEqual(
+      ['Isolated Joe', 'Eve', 'Adam', 'Bob'],
+      [row[0] for row in sorted(df.collect(), key=lambda row: row[1])])


### PR DESCRIPTION
It's just a few lines, but it makes the Spark–LynxKite integration much more friendly. From Spark to LynxKite:

```python
from pyspark.sql import Row, SparkSession
spark = SparkSession.builder.getOrCreate()
people_df = spark.createDataFrame([
    Row(name='Adam', age=23),
    Row(name='Eve', age=34),
    Row(name='Bob', age=45),
])
relationships_df = spark.createDataFrame([
    Row(a='Adam', b='Eve', weight=3),
    Row(a='Bob', b='Eve', weight=4),
    Row(a='Eve', b='Adam', weight=5),
])
g = lk.from_spark(people_df).useTableAsVertices()
g = lk.useTableAsEdges(
    g,
    lk.from_spark(relationships_df),
    attr='name', src='a', dst='b')
```

From LynxKite to Spark:
```python
t = g.sql('select count(*) from vertices')
t.spark(spark).show()
```

PySpark and LynxKite in this case still use separate Spark applications. But perhaps they are both dynamically scaled? The important thing is that this is a fully distributed data exchange between the two systems.