### PR TITLE
Add Import from BigQuery (table or SQL output)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
   "org.xerial" % "sqlite-jdbc" % "3.8.11.2",
   "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.6",
-  // The Google Cloud Storage connector for Spark and Hive
+  // Geotools
   "org.geotools" % "gt-shapefile" % "20.0",
   "org.geotools" % "gt-epsg-hsql" % "20.0",
   "org.locationtech.jts" % "jts" % "1.16.0",
@@ -78,6 +78,8 @@ libraryDependencies ++= Seq(
   // All kinds of parsing, e.g. filters.
   "com.lihaoyi" %% "fastparse" % "1.0.0",
   "org.scalaj" %% "scalaj-http" % "2.4.2",
+  // Google Dataproc's spark-bigquery-connector allows interacting with BigQuery tables on Dataproc
+   "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.25.0",
 )
 
 // We put the local Spark installation on the classpath for compilation and testing instead of using

--- a/web/app/help/operations/import-delta.asciidoc
+++ b/web/app/help/operations/import-delta.asciidoc
@@ -7,7 +7,7 @@ Import a Delta Table.
 The distributed file-system path of the file. See <<prefixed-paths>> for more details on specifying
 paths.
 
-[p-version_as_of]#Version As Of$::
+[p-version_as_of]#Version As Of#::
 Version of the Delta table to be imported. The empty string corresponds to the latest version.
 
 include::{g}[tag=import-box]

--- a/web/app/help/operations/import-from-bigquery-raw-table.asciidoc
+++ b/web/app/help/operations/import-from-bigquery-raw-table.asciidoc
@@ -1,0 +1,32 @@
+### Import from BigQuery (raw table)
+
+Import a table from BigQuery via Storage API without SQL query.
+Some BigQuery-specific datatypes like ARRAY<STRUCT> may not be fully supported within LynxKite
+More information here: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0
+
+====
+[p-parent_project_id]#GCP project ID for billing#::
+The GCP Project ID for billing purposes. This may be different from the dataset being read.
+`roles/bigquery.readSessionUser` is required on the billed project.
+`roles/bigquery.jobUser` is additionally required if using views.
+
+[p-project_id]#GCP project ID for importing#::
+Used together with dataset ID and table ID. Defaults to service account's GCP project if unspecified.
+
+[p-dataset_id]#BigQuery dataset ID for importing#::
+Used together with table ID to import. Requires `roles/bigquery.dataEditor` on the dataset to store
+materialized tables if querying from views.
+
+[p-table_id]#BigQuery table/view ID to import#::
+The BigQuery table/view to import from. Requires `roles/bigquery.dataViewer` on the view AND underlying table.
+
+[p-credentials_file]#Path to Service Account JSON key#::
+Local path to the service account JSON key to authenticate with GCP.
+Leave this field empty if running on Dataproc or to use `GOOGLE_APPLICATION_CREDENTIALS`.
+
+[p-views_enabled]#Allow reading from BigQuery views#::
+Allow reading from BigQuery views. Preliminary support.
+See https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0#reading-from-views
+
+include::{g}[tag=import-box]
+====

--- a/web/app/help/operations/import-from-bigquery-raw-table.asciidoc
+++ b/web/app/help/operations/import-from-bigquery-raw-table.asciidoc
@@ -1,8 +1,10 @@
 ### Import from BigQuery (raw table)
 
-Import a table from BigQuery via Storage API without SQL query.
-Some BigQuery-specific datatypes like ARRAY<STRUCT> may not be fully supported within LynxKite
-More information here: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0
+Import a table from BigQuery without a SQL query. (See also <<Import from BigQuery (Standard SQL result)>>.)
+
+Some BigQuery-specific datatypes like `ARRAY<STRUCT>` are not fully supported within LynxKite.
+
+BigQuery access is provided through the https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0#apache-spark-sql-connector-for-google-bigquery[Apache Spark SQL connector for Google BigQuery].
 
 ====
 [p-parent_project_id]#GCP project ID for billing#::

--- a/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
+++ b/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
@@ -1,8 +1,10 @@
 ### Import from BigQuery (Standard SQL result)
 
-Execute a BigQuery Standard SQL query and get the result via Storage API.
-Some BigQuery-specific datatypes like ARRAY<STRUCT> may not be fully supported within LynxKite
-More information here: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0
+Execute a BigQuery Standard SQL query and get the result as a table. (See also <<Import from BigQuery (raw table)>>.)
+
+Some BigQuery-specific datatypes like `ARRAY<STRUCT>` are not fully supported within LynxKite.
+
+BigQuery access is provided through the https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0#apache-spark-sql-connector-for-google-bigquery[Apache Spark SQL connector for Google BigQuery].
 
 ====
 [p-parent_project_id]#GCP project ID for billing#::

--- a/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
+++ b/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
@@ -1,0 +1,28 @@
+### Import from BigQuery (Standard SQL result)
+
+Execute a BigQuery Standard SQL query and get the result via Storage API.
+Some BigQuery-specific datatypes like ARRAY<STRUCT> may not be fully supported within LynxKite
+More information here: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0
+
+====
+[p-parent_project_id]#GCP project ID for billing#::
+The GCP Project ID for billing purposes. This may be different from the dataset being read.
+`roles/bigquery.readSessionUser` and `roles/bigquery.jobUser` are both required on the billed project.
+
+[p-materialization_project_id]#GCP project for materialization#::
+Used together with dataset ID. Defaults to service account's GCP project if unspecified.
+Requires `roles/bigquery.dataEditor` on the dataset.
+
+[p-materialization_dataset_id]#BigQuery Dataset for materialization#::
+Place to create temporary (24h) tables to store the results of the SQL query.
+Dataset must already exist with `roles/bigquery.dataEditor` granted on it.
+
+[p-bq_standard_sql]#BigQuery Standard SQL#::
+The SQL Query to run on BigQuery. `roles/bigquery.dataViewer` is required for SELECT.
+
+[p-credentials_file]#Path to Service Account JSON key#::
+Local path to the service account JSON key to authenticate with GCP.
+Leave this field empty if running on Dataproc or to use `GOOGLE_APPLICATION_CREDENTIALS`.
+
+include::{g}[tag=import-box]
+====

--- a/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
+++ b/web/app/help/operations/import-from-bigquery-standard-sql.asciidoc
@@ -18,7 +18,7 @@ Place to create temporary (24h) tables to store the results of the SQL query.
 Dataset must already exist with `roles/bigquery.dataEditor` granted on it.
 
 [p-bq_standard_sql]#BigQuery Standard SQL#::
-The SQL Query to run on BigQuery. `roles/bigquery.dataViewer` is required for SELECT.
+The SQL query to run on BigQuery. `roles/bigquery.dataViewer` is required for SELECT.
 
 [p-credentials_file]#Path to Service Account JSON key#::
 Local path to the service account JSON key to authenticate with GCP.

--- a/web/app/help/operations/index.asciidoc
+++ b/web/app/help/operations/index.asciidoc
@@ -417,6 +417,10 @@ include::import-csv.asciidoc[]
 
 include::import-delta.asciidoc[]
 
+include::import-from-bigquery-raw-table.asciidoc[]
+
+include::import-from-bigquery-standard-sql.asciidoc[]
+
 include::import-from-hive.asciidoc[]
 
 include::import-from-neo4j.asciidoc[]


### PR DESCRIPTION
Added feature to import from BigQuery using Google's [spark-bigquery-connector](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0).
There are two ways to read from BigQuery: raw table or result of executing BigQuery Standard SQL. Both methods are added as two separate import types.

Ability to export might come later. Also yet to implement the full set of [options / properties](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/0.25.0#properties).

It seemed to take too much time to mock GCP credentials and BigQuery, so no unit tests... 😬 