### PR TITLE
Force conda to use java11

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -15,6 +15,7 @@ dependencies:
 - make
 # For LynxKite backend.
 - sbt
+- openjdk==11.0.15 # if left unpinned, sbt now brings in unsupported jdk17
 # For LynxKite frontend.
 - nodejs
 - yarn


### PR DESCRIPTION
Temporary workaround for #265 