### PR TITLE
Fix paragraphs overlapping in comments

### DIFF
--- a/web/app/styles/workspace.css
+++ b/web/app/styles/workspace.css
@@ -300,6 +300,10 @@ op-editor > :first-child {
   padding-top: 10px;
 }
 
+.workspace-comment {
+  display: block;
+}
+
 .workspace-comment > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
I'm not sure when this happened — I just noticed it on try.lynxkite.com. I don't think we have changed this recently, so maybe it's a change in Chrome?

|before fix|after fix|
|---|---|
|<img width="507" alt="image" src="https://user-images.githubusercontent.com/1268018/189652923-d81012d9-babb-4594-a624-af1896ce625b.png">|<img width="501" alt="image" src="https://user-images.githubusercontent.com/1268018/189653039-911cf280-13e8-47f0-84a8-5742666369c8.png">|