### PR TITLE
Fix custom plots when served with a prefix

### DIFF
--- a/app/com/lynxanalytics/biggraph/frontend_operations/VisualizationOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/VisualizationOperations.scala
@@ -129,7 +129,7 @@ class VisualizationOperations(env: SparkFreeEnvironment) extends OperationRegist
             throw e
         }
       val limit = 10000
-      val tableURL = s"/downloadCSV?q=%7B%22id%22:%22${table.gUID.toString}%22,%22sampleRows%22:$limit%7D"
+      val tableURL = s"downloadCSV?q=%7B%22id%22:%22${table.gUID.toString}%22,%22sampleRows%22:$limit%7D"
       json.Json.obj("data" -> json.Json.obj(
         "url" -> tableURL,
         "format" -> json.Json.obj("type" -> "csv"))) ++ j

--- a/test/com/lynxanalytics/biggraph/frontend_operations/PlotTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/PlotTest.scala
@@ -21,7 +21,7 @@ class PlotTest extends OperationsTestBase {
     }
   },
   "data": {
-    "url": "/downloadCSV?q=%7B%22id%22:%221df989fa-d79d-31c2-8baa-69a9553266fb%22,%22sampleRows%22:10000%7D",
+    "url": "downloadCSV?q=%7B%22id%22:%221df989fa-d79d-31c2-8baa-69a9553266fb%22,%22sampleRows%22:10000%7D",
     "format": {"type": "csv"}
   }
 }"""))


### PR DESCRIPTION
Like if LynxKite is served as `https://demo.lynxkite.com/user/.../lk/`, then we can't redirect to `/downloadCSV`. But `downloadCSV` works, because the frontend is served from the LynxKite root.