### PR TITLE
Use placeholder for unused "secret"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,6 +8,7 @@ akka.http.parsing.max-uri-length = 999999
 play.server.akka.requestTimeout = infinite
 play.server.akka.terminationTimeout = null
 play.server.http.idleTimeout = infinite
+play.http.secret.key = SECRET-KEY-NOT-NEEDED-NO-AUTHENTICATION-CONFIGURED
 http.port = 2200
 https.port = 2201
 

--- a/run.sh
+++ b/run.sh
@@ -6,5 +6,4 @@ tools/install_spark.sh
 make backend
 . ~/.kiterc
 $SPARK_HOME/bin/spark-submit \
-  --conf 'spark.driver.extraJavaOptions=-Dplay.http.secret.key=SECRET-TEST-TEST-TEST-TEST' \
   target/scala-2.12/lynxkite-0.1-SNAPSHOT.jar


### PR DESCRIPTION
While writing the release notes I realized this is unused. We're not managing sessions. So let's not put an unnecessary burden on the caller.