### PR TITLE
Fix Python docs

### DIFF
--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -922,6 +922,7 @@ class State:
     ```
     graph = lk.createExampleGraph().findConnectedComponents(name='seg1')
     segmentation = graph.segmentation('seg1')
+    ```
     '''
     return self.takeSegmentationAsBaseGraph(apply_to_graph='.' + name)
 


### PR DESCRIPTION
This unclosed block was causing the API docs to fail to get generated.