### PR TITLE
Disable Play Framework pidfile

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,6 +8,7 @@ akka.http.parsing.max-uri-length = 999999
 play.server.akka.requestTimeout = infinite
 play.server.akka.terminationTimeout = null
 play.server.http.idleTimeout = infinite
+play.server.pidfile.path = "/dev/null"
 play.http.secret.key = SECRET-KEY-NOT-NEEDED-NO-AUTHENTICATION-CONFIGURED
 http.port = 2200
 https.port = 2201


### PR DESCRIPTION
This was creating a file called `RUNNING_PID`. I'm on a crusade against PID files. The port (2200) is a perfectly good protection against accidentally running multiple LynxKites.