### PR TITLE
Do not pass LynxKite objects to ScalaScript

### DIFF
--- a/app/com/lynxanalytics/biggraph/scala_sandbox/ScalaScript.scala
+++ b/app/com/lynxanalytics/biggraph/scala_sandbox/ScalaScript.scala
@@ -20,10 +20,6 @@ import scala.reflect.runtime.universe._
 import scala.tools.nsc.interpreter.Scripted
 import scala.util.DynamicVariable
 
-// For describing project structure in parametric parameters.
-// This needs to be in this package for the sandboxed scripts to access it.
-case class SimpleGraphEntity(name: String, typeName: String)
-
 object ScalaScriptSecurityManager {
   private[scala_sandbox] val restrictedSecurityManager = new ScalaScriptSecurityManager
   System.setSecurityManager(restrictedSecurityManager)


### PR DESCRIPTION
Fixes #303. I think the Map would be a fine API too. But to preserve compatibility I'm converting them to the same SimpleGraphEntity, but defined inside ScalaScript.

Unfortunately the backend tests cannot catch this, because they are not running with `spark-submit`. A frontend test could have caught it. I haven't added one here because we're in the process of rewriting them. But I've filed #304 so we don't forget.