### PR TITLE
Convert histogram-test.js and filter-test.js

### DIFF
--- a/app/com/lynxanalytics/biggraph/controllers/FEBucketers.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/FEBucketers.scala
@@ -23,10 +23,12 @@ object FEBucketers {
     val bucketer =
       if (typeOf[T] =:= typeOf[String]) {
         val op = ComputeTopValues[String](numBuckets + 1, 10000)
-        val topVals = op(op.attribute, attr.runtimeSafeCast[String]).result.topValues.value.map(_._1)
-        val hasOther = topVals.size == numBuckets + 1
-        (if (hasOther) StringBucketer(topVals.takeRight(numBuckets - 1), true)
-         else StringBucketer(topVals, false))
+        val topVals = op(op.attribute, attr.runtimeSafeCast[String]).result.topValues.value
+        // Sort by decreasing counts, break ties alphabetically.
+        val sorted = topVals.sortBy(_._1).sortBy(-_._2).map(_._1)
+        val hasOther = sorted.size == numBuckets + 1
+        (if (hasOther) StringBucketer(sorted.take(numBuckets - 1), true)
+         else StringBucketer(sorted, false))
           .asInstanceOf[Bucketer[T]]
       } else if (typeOf[T] =:= typeOf[Double]) {
         val stats = {

--- a/test/com/lynxanalytics/biggraph/controllers/GraphDrawingControllerTest.scala
+++ b/test/com/lynxanalytics/biggraph/controllers/GraphDrawingControllerTest.scala
@@ -212,16 +212,16 @@ class GraphDrawingControllerTest extends AnyFunSuite with TestGraphOp {
     assert(res.vertexSets(0).mode == "bucketed")
     assert(res.vertexSets(0).vertices.size == 4)
     assert(res.vertexSets(0).vertices.toSet == Set(
-      FEVertex(1.0, 0, 0),
-      FEVertex(2.0, 0, 1),
-      FEVertex(0.0, 1, 0),
-      FEVertex(1.0, 1, 1)))
+      FEVertex(1.0, 0, 1),
+      FEVertex(2.0, 0, 0),
+      FEVertex(0.0, 1, 1),
+      FEVertex(1.0, 1, 0)))
     assert(res.edgeBundles(0).edges.size == 4)
     assert(res.edgeBundles(0).edges.toSet == Set(
       FEEdge(0, 1, 1.0),
-      FEEdge(3, 0, 1.0),
+      FEEdge(2, 0, 1.0),
       FEEdge(1, 0, 1.0),
-      FEEdge(3, 1, 1.0)))
+      FEEdge(2, 1, 1.0)))
   }
 
   test("relative edge density") {
@@ -459,8 +459,8 @@ class GraphDrawingControllerTest extends AnyFunSuite with TestGraphOp {
       sampleSize = 50000)
     val res = Await.result(controller.getHistogram(user, req), duration.Duration.Inf)
     assert(res.labelType == "bucket")
-    assert(res.labels == Seq("Female", "Male"))
-    assert(res.sizes == Seq(1, 3))
+    assert(res.labels == Seq("Male", "Female"))
+    assert(res.sizes == Seq(3, 1))
   }
 
   test("histogram for edges") {

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
     "vega-lite": "^5.1.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.27.1",
+    "@playwright/test": "^1.28.1",
     "angular-mocks": "1.8.2",
     "asciidoctor.js": "1.5.9",
     "browser-sync": "2.26.14",

--- a/web/tests/custom-box.spec.ts
+++ b/web/tests/custom-box.spec.ts
@@ -4,7 +4,7 @@ import { Workspace } from './lynxkite';
 
 let workspace: Workspace;
 
-test('create custom box', async function ({ browser }) {
+test.skip('create custom box', async function ({ browser }) {
     workspace = await Workspace.empty(browser);
     await workspace.addWorkspaceParameter('prname', 'text', 'default_pr');
     await workspace.addBox({ id: 'in', name: 'Input', x: 100, y: 0, params: { name: 'in' } });

--- a/web/tests/filter.spec.ts
+++ b/web/tests/filter.spec.ts
@@ -1,0 +1,31 @@
+// Tests filtering with the "Filter by attributes" box.
+import { test, expect } from '@playwright/test';
+import { Workspace } from './lynxkite';
+
+let workspace: Workspace;
+test.beforeAll(async ({ browser }) => {
+  workspace = await Workspace.empty(browser);
+  await workspace.addBox({ id: 'ex0', name: 'Create example graph', x: 100, y: 100 });
+  await workspace.addBox({
+    id: 'filter0',
+    name: 'Filter by attributes',
+    x: 100, y: 400, after: 'ex0', params: {
+      'filterva_age': '<40',
+      'filterva_name': 'Adam,Eve,Bob',
+      'filterea_weight': '!1',
+    }
+  });
+});
+
+test('histograms after hard filters', async () => {
+  const state = await workspace.openStateView('filter0', 'graph');
+  await expect(state.left.vertexCount).toHaveText('2');
+  await expect(state.left.edgeCount).toHaveText('1');
+  expect(await state.left.vertexAttribute('name').getHistogramValues()).toEqual([
+    { title: 'Adam', size: 100, value: 1 },
+    { title: 'Eve', size: 100, value: 1 },
+  ]);
+  expect(await state.left.edgeAttribute('weight').getHistogramValues()).toEqual([
+    { title: '2.00-2.00', size: 100, value: 1 },
+  ]);
+});

--- a/web/tests/histogram.spec.ts
+++ b/web/tests/histogram.spec.ts
@@ -1,0 +1,130 @@
+// Tests for the histograms displayed for vertex/edge attributes.
+import { test, expect } from '@playwright/test';
+import { State, Workspace } from './lynxkite';
+
+let workspace: Workspace;
+let state: State;
+test.beforeAll(async ({ browser }) => {
+  workspace = await Workspace.empty(browser);
+  await workspace.addBox({ id: 'ex0', name: 'Create example graph', x: 100, y: 100 });
+  state = await workspace.openStateView('ex0', 'graph');
+});
+
+test('string vertex histogram', async () => {
+  await expect(state.left.side).toHaveCount(1);
+  expect(await state.left.vertexAttribute('name').getHistogramValues()).toEqual([
+    { title: 'Adam', size: 100, value: 1 },
+    { title: 'Bob', size: 100, value: 1 },
+    { title: 'Eve', size: 100, value: 1 },
+    { title: 'Isolated Joe', size: 100, value: 1 },
+  ]);
+});
+test('double vertex histogram', async () => {
+  expect(await state.left.vertexAttribute('income').getHistogramValues()).toEqual([
+    { title: '1000.0-1050.0', size: 100, value: 1 },
+    { title: '1050.0-1100.0', size: 0, value: 0 },
+    { title: '1100.0-1150.0', size: 0, value: 0 },
+    { title: '1150.0-1200.0', size: 0, value: 0 },
+    { title: '1200.0-1250.0', size: 0, value: 0 },
+    { title: '1250.0-1300.0', size: 0, value: 0 },
+    { title: '1300.0-1350.0', size: 0, value: 0 },
+    { title: '1350.0-1400.0', size: 0, value: 0 },
+    { title: '1400.0-1450.0', size: 0, value: 0 },
+    { title: '1450.0-1500.0', size: 0, value: 0 },
+    { title: '1500.0-1550.0', size: 0, value: 0 },
+    { title: '1550.0-1600.0', size: 0, value: 0 },
+    { title: '1600.0-1650.0', size: 0, value: 0 },
+    { title: '1650.0-1700.0', size: 0, value: 0 },
+    { title: '1700.0-1750.0', size: 0, value: 0 },
+    { title: '1750.0-1800.0', size: 0, value: 0 },
+    { title: '1800.0-1850.0', size: 0, value: 0 },
+    { title: '1850.0-1900.0', size: 0, value: 0 },
+    { title: '1900.0-1950.0', size: 0, value: 0 },
+    { title: '1950.0-2000.0', size: 100, value: 1 },
+  ]);
+});
+test('double edge histogram', async () => {
+  expect(await state.left.edgeAttribute('weight').getHistogramValues()).toEqual([
+    { title: '1.00-1.15', size: 100, value: 1 },
+    { title: '1.15-1.30', size: 0, value: 0 },
+    { title: '1.30-1.45', size: 0, value: 0 },
+    { title: '1.45-1.60', size: 0, value: 0 },
+    { title: '1.60-1.75', size: 0, value: 0 },
+    { title: '1.75-1.90', size: 0, value: 0 },
+    { title: '1.90-2.05', size: 100, value: 1 },
+    { title: '2.05-2.20', size: 0, value: 0 },
+    { title: '2.20-2.35', size: 0, value: 0 },
+    { title: '2.35-2.50', size: 0, value: 0 },
+    { title: '2.50-2.65', size: 0, value: 0 },
+    { title: '2.65-2.80', size: 0, value: 0 },
+    { title: '2.80-2.95', size: 0, value: 0 },
+    { title: '2.95-3.10', size: 100, value: 1 },
+    { title: '3.10-3.25', size: 0, value: 0 },
+    { title: '3.25-3.40', size: 0, value: 0 },
+    { title: '3.40-3.55', size: 0, value: 0 },
+    { title: '3.55-3.70', size: 0, value: 0 },
+    { title: '3.70-3.85', size: 0, value: 0 },
+    { title: '3.85-4.00', size: 100, value: 1 },
+  ]);
+});
+
+test('soft filters are applied to string vertex histogram', async () => {
+  await state.left.vertexAttribute('name').setFilter('Adam,Eve,Bob');
+  await state.left.vertexAttribute('age').setFilter('<40');
+  expect(await state.left.vertexAttribute('name').getHistogramValues()).toEqual([
+    { title: 'Adam', size: 100, value: 1 },
+    { title: 'Bob', size: 0, value: 0 },
+    { title: 'Eve', size: 100, value: 1 },
+    { title: 'Isolated Joe', size: 0, value: 0 },
+  ]);
+});
+
+test('soft filters are applied to double edge histogram', async () => {
+  await state.left.edgeAttribute('weight').setFilter('!1');
+  expect(await state.left.edgeAttribute('weight').getHistogramValues()).toEqual([
+    { title: '1.00-1.15', size: 0, value: 0 },
+    { title: '1.15-1.30', size: 0, value: 0 },
+    { title: '1.30-1.45', size: 0, value: 0 },
+    { title: '1.45-1.60', size: 0, value: 0 },
+    { title: '1.60-1.75', size: 0, value: 0 },
+    { title: '1.75-1.90', size: 0, value: 0 },
+    { title: '1.90-2.05', size: 100, value: 1 },
+    { title: '2.05-2.20', size: 0, value: 0 },
+    { title: '2.20-2.35', size: 0, value: 0 },
+    { title: '2.35-2.50', size: 0, value: 0 },
+    { title: '2.50-2.65', size: 0, value: 0 },
+    { title: '2.65-2.80', size: 0, value: 0 },
+    { title: '2.80-2.95', size: 0, value: 0 },
+    { title: '2.95-3.10', size: 0, value: 0 },
+    { title: '3.10-3.25', size: 0, value: 0 },
+    { title: '3.25-3.40', size: 0, value: 0 },
+    { title: '3.40-3.55', size: 0, value: 0 },
+    { title: '3.55-3.70', size: 0, value: 0 },
+    { title: '3.70-3.85', size: 0, value: 0 },
+    { title: '3.85-4.00', size: 0, value: 0 },
+  ]);
+});
+test('precise mode histogram has precise number for large datasets', async () => {
+  await workspace.addBox({
+    id: 'create-vertices',
+    name: 'Create vertices',
+    x: 100,
+    y: 100,
+    params: { size: '123456' },
+  });
+  await workspace.addBox({
+    id: 'add-attr',
+    name: 'Add constant vertex attribute',
+    x: 100,
+    y: 200,
+    after: 'create-vertices',
+    params: { name: 'c' },
+  });
+  const state = await workspace.openStateView('add-attr', 'graph');
+  expect(await state.left.vertexAttribute('c').getHistogramValues()).toEqual([
+    { title: '1.00-1.00', size: 100, value: 123450 },
+  ]);
+  expect(await state.left.vertexAttribute('c').getHistogramValues({ precise: true })).toEqual([
+    { title: '1.00-1.00', size: 100, value: 123456 },
+  ]);
+});

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -71,7 +71,7 @@ export class Entity {
       await popup.locator('#precise-histogram-calculation').click();
     }
     // Wait for the histogram to be loaded.
-    await expect(histogram.locator('.loading')).toHaveCount(0);
+    await expect(histogram.locator('.loading')).toHaveCount(0, { timeout: 30_000 });
     return histogram;
   }
 

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -7,6 +7,12 @@ function toId(x) {
   return x.toLowerCase().replace(/ /g, '-');
 }
 
+const numberFormat = new Intl.NumberFormat('en-US', { maximumFractionDigits: 5 });
+// Same number formatting as used by LynxKite.
+export function humanize(x) {
+  return numberFormat.format(x);
+}
+
 async function clickAll(elements: Locator, opts) {
   const n = await elements.count();
   // Clicking may remove them from the selector. So we start from the end.
@@ -32,28 +38,27 @@ export class Entity {
   }
 
   async popup() {
-    if (!(await this.menu.isVisible())) {
-      this.element.click();
+    if ((await this.menu.count()) == 0) {
+      await this.element.click();
     }
-    expect(this.menu).toBeVisible();
+    await expect(this.menu).toBeVisible();
     return this.menu;
   }
 
   async popoff() {
-    if (await this.element.isVisible()) {
-      angularEval(this.element, 'closeMenu()');
+    if ((await this.element.count()) > 0) {
+      await angularEval(this.element, 'closeMenu()');
     }
-    expect(this.menu).not.toBeVisible();
+    await expect(this.menu).not.toBeVisible();
   }
 
   async setFilter(filterValue) {
-    const filterBox = this.popup().locator('#filter');
-    filterBox.clear();
-    safeSendKeys(filterBox, filterValue).submit();
-    this.popoff();
+    const filterBox = (await this.popup()).locator('#filter');
+    await filterBox.fill(filterValue);
+    await this.popoff();
   }
 
-  async openHistogram(precise: boolean = false) {
+  async openHistogram(opts?: { precise?: boolean }) {
     const popup = await this.popup();
     const histogram = popup.locator('histogram');
     // The histogram will be automatically displayed if the attribute is already computed.
@@ -62,7 +67,7 @@ export class Entity {
       await popup.locator('#show-histogram').click();
     }
     await expect(histogram).toBeVisible();
-    if (precise) {
+    if (opts?.precise) {
       await popup.locator('#precise-histogram-calculation').click();
     }
     // Wait for the histogram to be loaded.
@@ -70,12 +75,12 @@ export class Entity {
     return histogram;
   }
 
-  async getHistogramValues(precise: boolean = false) {
-    const histogram = await this.openHistogram(precise);
+  async getHistogramValues(opts?: { precise?: boolean }) {
+    const histogram = await this.openHistogram(opts);
     const tds = histogram.locator('.bar-container');
     const tdCount = await tds.count();
     let total = 0;
-    const res = [] as { title: string, value: number, size: number }[];
+    const res = [] as { title: string; value: number; size: number }[];
     for (let i = 0; i < tdCount; ++i) {
       const td = tds.nth(i);
       const toolTip = await td.getAttribute('drop-tooltip');
@@ -85,7 +90,7 @@ export class Entity {
       total += parseInt(value);
       res.push({ title, value: parseInt(value), size: parseInt(size) });
     }
-    await expect(histogram.locator('#histogram-total')).toContainText(total.toString());
+    await expect(histogram.locator('#histogram-total')).toContainText(humanize(total));
     await this.popoff();
     return res;
   }
@@ -434,7 +439,7 @@ export class BoxEditor extends PopupBase {
   }
 }
 
-class State extends PopupBase {
+export class State extends PopupBase {
   popup: Locator;
   left: Side;
   right: Side;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -329,13 +329,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/test@^1.27.1":
-  version "1.27.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.27.1.tgz#9364d1e02021261211c8ff586d903faa79ce95c4"
-  integrity sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==
+"@playwright/test@^1.28.1":
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
+  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.27.1"
+    playwright-core "1.28.1"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -416,6 +416,11 @@
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
   integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
+
+"@types/node@^18.11.15":
+  version "18.11.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.15.tgz#de0e1fbd2b22b962d45971431e2ae696643d3f5d"
+  integrity sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==
 
 "@types/q@^0.0.32":
   version "0.0.32"
@@ -4484,10 +4489,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-playwright-core@1.27.1:
-  version "1.27.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.27.1.tgz#840ef662e55a3ed759d8b5d3d00a5f885a7184f4"
-  integrity sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==
+playwright-core@1.28.1:
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
+  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
 plugin-error@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
The histogram test used to include sorting, because the histograms come in unpredictable order. But that's not great for the users either! I've fixed the sorting on the backend.