### PR TITLE
Use DataFrames from PySpark without writing them to disk

### DIFF
--- a/app/com/lynxanalytics/biggraph/LynxKite.scala
+++ b/app/com/lynxanalytics/biggraph/LynxKite.scala
@@ -93,4 +93,14 @@ object LynxKite {
       Environment.get.toSeq: _*).run()
     sphynxProcess
   }
+
+  def importDataFrame(df: org.apache.spark.sql.DataFrame): String = synchronized {
+    assert(playServer != null, "LynxKite is not running! Call start() first.")
+    val env = BigGraphProductionEnvironment
+    assert(df.sparkSession == env.sparkSession, "The DataFrame is not from the SparkSession that was used to start LynxKite.")
+    implicit val mm = env.metaGraphManager
+    import com.lynxanalytics.biggraph.graph_api.Scripting._
+    val t = graph_operations.ImportDataFrame.run(df)
+    return t.gUID.toString
+  }
 }

--- a/python/remote_api/src/lynx/kite.py
+++ b/python/remote_api/src/lynx/kite.py
@@ -340,6 +340,8 @@ class LynxKite:
     spark = SparkSession.builder.config('spark.jars', 'lynxkite-X.X.X.jar').getOrCreate()
   '''
 
+  _managed = None
+
   def __init__(self, username: Optional[str] = None, password: Optional[str] = None, address: Optional[str] = None,
                certfile: Optional[str] = None, oauth_token: Optional[str] = None, signed_token: Optional[str] = None,
                box_catalog: Optional[BoxCatalog] = None, spark: Optional['SparkSession'] = None) -> None:
@@ -368,12 +370,17 @@ class LynxKite:
         'exportGraphToNeo4j']
     self._box_catalog = box_catalog  # TODO: create standard offline box catalog
 
+    self._lynxkite = None
     if spark:
       assert address is None, \
           'Do not specify connection parameters when this class is responsible for starting LynxKite.'
-      self._lynxkite = ManagedLynxKite(spark)
+      if LynxKite._managed:
+        assert LynxKite._managed.spark == spark, 'LynxKite is already running in another Spark session.'
+      else:
+        LynxKite._managed = ManagedLynxKite(spark)
+        LynxKite._managed.start()
+      self._lynxkite = LynxKite._managed
       self._address = self._lynxkite.address
-      self._lynxkite.start()
 
   def home(self) -> str:
     return f'Users/{self.username()}/'
@@ -864,15 +871,21 @@ class LynxKite:
       df.to_parquet(f.name, **kwargs)
       return self.uploadParquetNow(f.read())
 
-  def from_spark(self, df):
+  def from_spark(self, df, *, write_parquet=False):
     '''
     Converts a Spark DataFrame to a LynxKite table.
-    Costs almost nothing if LynxKite was started in the same SparkSession.
+
+    Set "write_parquet" to pass in the DataFrame by writing it as a Parquet file.
+    This is slower, but works even if LynxKite and PySpark are in separate Spark sessions.
     '''
-    if self._lynxkite:
-      # The DataFrame is in the same JVM! We can use it directly.
+    if write_parquet:
+      filename = 'DATA$/python-imports/' + datetime.datetime.now().strftime('%Y-%d-%m_%H%M%S.%f')
+      resolved = self.get_prefixed_path(filename).resolved
+      df.write.parquet(resolved)
+      return self.importParquetNow(filename=filename)
+    else:
+      assert self._lynxkite, 'Run LynxKite in the same Spark session, or use "write_parquet".'
       guid = self._lynxkite.importDataFrame(df)
-      print('guid:', guid)
       return SingleOutputAtomicBox(
           self.box_catalog(), self, 'importParquet', inputs={}, parameters={
               'filename': 'from PySpark',
@@ -883,12 +896,6 @@ class LynxKite:
               }),
           },
           output_name='table')
-    else:
-      # Pass it through a Parquet file.
-      filename = 'DATA$/python-imports/' + datetime.datetime.now().strftime('%Y-%d-%m_%H%M%S.%f')
-      resolved = self.get_prefixed_path(filename).resolved
-      df.write.parquet(resolved)
-      return self.importParquetNow(filename=filename)
 
   def set_executors(self, count):
     return self._send('/remote/setExecutors', {'count': count})

--- a/python/remote_api/tests/test_spark_conversion.py
+++ b/python/remote_api/tests/test_spark_conversion.py
@@ -19,10 +19,10 @@ class TestSparkConversion(unittest.TestCase):
         Row(a='Bob', b='Eve', weight=4),
         Row(a='Eve', b='Adam', weight=5),
     ])
-    g = lk.from_spark(people_df).useTableAsVertices()
+    g = lk.from_spark(people_df, write_parquet=True).useTableAsVertices()
     g = lk.useTableAsEdges(
         g,
-        lk.from_spark(relationships_df),
+        lk.from_spark(relationships_df, write_parquet=True),
         attr='name', src='a', dst='b')
     self.assertEqual(3, g.sql('select count(*) from vertices').df().values[0][0])
 


### PR DESCRIPTION
I'll add a test! For now I've tested it manually like this:

```
from pyspark.sql import Row
import lynx.kite
lk = lynx.kite.LynxKite(spark=spark)
df = spark.createDataFrame([Row(name='Adam', age=23), Row(name='Eve', age=34), Row(name='Bob', age=45)])
print(lk.from_spark(df).sql('select * from input where age < 40').df())
```

It's so cool! I'm also going to add the other direction in another PR: LynxKite table to PySpark DataFrame.