### PR TITLE
Migrate errors-test.js to Playwright

### DIFF
--- a/web/tests/errors.spec.ts
+++ b/web/tests/errors.spec.ts
@@ -1,0 +1,50 @@
+// Tests error reporting.
+import { test, expect } from '@playwright/test';
+import { Workspace } from './lynxkite';
+
+let workspace: Workspace;
+test.beforeAll(async ({ browser }) => {
+  workspace = await Workspace.empty(await browser.newPage(), 'errors');
+  await workspace.addBox({ id: 'eg', name: 'Create example graph', x: 100, y: 100 });
+});
+
+test('unconnected inputs', async () => {
+  await workspace.addBox({ id: 'sql', name: 'SQL1', x: 300, y: 150 });
+  const editor = await workspace.openBoxEditor('sql');
+  await expect(editor.element).toContainText('Cannot retrieve box metadata.');
+  await expect(editor.element).toContainText('Input input of box sql is not connected.');
+  const state = await workspace.openStateView('sql', 'table');
+  await expect(state.popup).toContainText('Failed to generate output state.');
+  await expect(state.popup).toContainText('Input input of box sql is not connected.');
+  // But after connecting it it works.
+  await workspace.connectBoxes('eg', 'graph', 'sql', 'input');
+  await expect(editor.element).toContainText('Summary');
+  await expect(state.popup).toContainText('Isolated Joe');
+  await workspace.deleteBoxes(['sql']);
+});
+
+test('error in scalar', async () => {
+  await workspace.addBox({
+    id: 'x', name: 'Derive vertex attribute', x: 100, y: 200, after: 'eg', params: {
+      output: 'empty', expr: 'Option.empty[Double]',
+    }});
+  await workspace.addBox({
+    id: 'aggr', name: 'Aggregate vertex attribute globally', x: 100, y: 300, after: 'x', params: {
+      aggregate_income: ['average'], aggregate_empty: ['average', 'sum'],
+    }});
+  const state = await workspace.openStateView('aggr', 'graph');
+  await expect(state.left.graphAttributes.locator('.title')).toHaveText([
+    'empty_average', 'empty_sum', 'greeting', 'income_average']);
+  await expect(state.left.graphAttributes.locator('value')).toContainText([
+    '↻', '0', 'Hello world! 😀', '2k']);
+  // Check non-error behavior while we're here.
+  await state.left.graphAttribute('income_average').element.locator('value').click();
+  await expect(state.left.graphAttributes.locator('value')).toContainText([
+    '↻', '0', 'Hello world! 😀', '1500']);
+  // Check error.
+  await state.left.graphAttribute('empty_average').element.locator('.value-error').click();
+  const modal = workspace.page.locator('.modal-dialog');
+  await expect(modal).toContainText('Average of empty set');
+  await modal.locator('#close-modal-button').click();
+  await expect(modal).not.toBeVisible();
+});

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -132,11 +132,9 @@ export class Workspace {
   }
 
   // Starts with a brand new workspace.
-  static async empty(page: Page): Promise<Workspace> {
+  static async empty(page: Page, workspaceName?: string): Promise<Workspace> {
     const splash = await Splash.open(page);
-    const workspace = await splash.openNewWorkspace('test-example');
-    await workspace.expectCurrentWorkspaceIs('test-example');
-    return workspace;
+    return await splash.openNewWorkspace(workspaceName ?? 'test-example');
   }
 
   async expectCurrentWorkspaceIs(name) {
@@ -548,7 +546,7 @@ class Side {
   edgeAttribute(name: string) {
     return new Entity(this.side, 'edge-attribute', name);
   }
-  scalar(name: string) {
+  graphAttribute(name: string) {
     return new Entity(this.side, 'scalar', name);
   }
   segmentation(name: string) {
@@ -779,6 +777,7 @@ export class Splash {
     const ws = new Workspace(this.page);
     // This expect() waits for the workspace to load.
     await expect(ws.getBox('anchor')).toBeVisible();
+    await ws.expectCurrentWorkspaceIs(name);
     return ws;
   }
 


### PR DESCRIPTION
For #238. The original of this test was commented out. I revived it a bit reluctantly. Who cares specifically about error reporting for scalars? I still did it and it immediately uncovered a bug. 🤯 

A bit about the bug: it only happens if you run the test a second time. The first time the graph state is opened, the scalars are uncomputed. Computation starts, you see the spinner, then it fails and you see the error ❌.

But if you reload the page and try again (or re-run the test) the computation has already failed when you open the popup. In `getComputedScalarValue` we go on the "-1" branch. On that branch we call `getFuture` and take the error from the returned future. But `getFuture` will never return a future with an error. If the future has already failed, `getFuture` retries. This means the error is not displayed, and there is a retry running without a progress indicator.

I've added a `retry` parameter to `getFuture` so we can get the existing failure with `retry=false`. An alternative would be to just not use `getFuture` here. Look inside `futures` ourselves.