### PR TITLE
Allow specifying custom examples for OpenAI

### DIFF
--- a/resources/built-ins/ask-OpenAI
+++ b/resources/built-ins/ask-OpenAI
@@ -13,20 +13,62 @@ boxes:
       intention.
 
 
-      "Query" can be a free-form natural language query. English works best.
+      **"Query"** can be a free-form natural language query. English works best.
 
       For example, you could type `the 10 most important cities`.
 
 
-      "Result schema" is the schema of the output you want to see.
+      **"Result schema"** is the schema of the output you want to see.
 
-      This is a comma-separated list of columns. For each column the type is indicated after a colon.
+      This is a comma-separated list of columns. For each column the type is
+      indicated after a colon.
 
       For example, it could be `city: str, importance: float`.
-    icon: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/OpenAI_Logo.svg/800px-OpenAI_Logo.svg.png
+
+
+      **"Examples"** is optional. Specify a list of queries and the Python code
+      that
+
+      should be generated for them. The Python code should be the body of a
+      function
+
+      that uses the `nodes` and `edges` DataFrames and returns a DataFrame with
+      the answer.
+
+      Format the examples in the following way:
+
+
+      ```python
+
+      the city with the highest population:
+        return nodes.nlargest(1, 'population')
+
+      find the top 3 most important cities:
+        pr = nodes['pagerank']
+        pop = nodes['population']
+        nodes['importance'] = (pr + 1) * np.sqrt(pop)
+        return nodes.nlargest(3, 'importance')
+      ```
+
+
+      If you don't specify custom examples, a list of generic graph queries is
+      used.
+
+      Custom examples are very powerful but often not necessary. Try
+      precomputing
+
+      attributes first. In the example you could precompute your unusual
+      `importance`
+
+      metric instead of trusting the model with it. Using meaningful attribute
+      names
+
+      helps a lot too.
+    icon: >-
+      https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/OpenAI_Logo.svg/800px-OpenAI_Logo.svg.png
     parameters: >-
       [{"kind":"text","id":"Query","defaultValue":"","$$hashKey":"object:580"},{"kind":"text","id":"Result
-      schema","defaultValue":"","$$hashKey":"object:631"}]
+      schema","defaultValue":"","$$hashKey":"object:631"},{"kind":"text","id":"Examp","defaultValue":"","$$hashKey":"object:2531"}]
   parametricParameters: {}
   x: 0
   y: 0
@@ -50,16 +92,16 @@ boxes:
       ${vertexAttributes.map("vs."+_.name).mkString(",")},
       ${edgeAttributes.map("es."+_.name).mkString(",")}, es.src, es.dst
     outputs: ${`Result schema`.split(",").map(e => "df." + e.strip()).mkString(",")}
-  x: 200
-  y: 150
+  x: 750
+  y: 50
 - id: input-graph
   inputs: {}
   operationId: Input
   parameters:
     name: graph
   parametricParameters: {}
-  x: 0
-  y: 150
+  x: 550
+  y: 50
 - id: output-graph
   inputs:
     output:
@@ -69,5 +111,5 @@ boxes:
   parameters:
     name: graph
   parametricParameters: {}
-  x: 400
-  y: 150
+  x: 950
+  y: 50

--- a/sphynx/python/derive.py
+++ b/sphynx/python/derive.py
@@ -31,11 +31,11 @@ vs = pd.DataFrame(vs)
 es = pd.DataFrame(es)
 
 
-def ai(query, output_schema):
+def ai(query, output_schema, examples=None):
   '''A utility for running the default large language model and putting the result in "df".'''
   from .llm_pandas_on_graph import pandas_on_graph
   global df
-  df = pandas_on_graph(nodes=vs, edges=es, query=query, output_schema=output_schema)
+  df = pandas_on_graph(nodes=vs, edges=es, query=query, output_schema=output_schema, examples=examples)
   # Clean up the table in case it has anything unwanted.
   wanted = [col['name'] for col in op.params['outputFields'] if col['parent'] == 'df']
   df = df.reset_index(drop=True)[wanted]

--- a/sphynx/python/derive.py
+++ b/sphynx/python/derive.py
@@ -33,9 +33,14 @@ es = pd.DataFrame(es)
 
 def ai(query, output_schema, examples=None):
   '''A utility for running the default large language model and putting the result in "df".'''
-  from .llm_pandas_on_graph import pandas_on_graph
+  from . import llm_pandas_on_graph as llm
   global df
-  df = pandas_on_graph(nodes=vs, edges=es, query=query, output_schema=output_schema, examples=examples)
+  df = llm.pandas_on_graph(
+      nodes=vs,
+      edges=es,
+      query=query,
+      output_schema=output_schema,
+      examples=llm.parse_examples(examples))
   # Clean up the table in case it has anything unwanted.
   wanted = [col['name'] for col in op.params['outputFields'] if col['parent'] == 'df']
   df = df.reset_index(drop=True)[wanted]

--- a/sphynx/python/llm_pandas_on_graph.py
+++ b/sphynx/python/llm_pandas_on_graph.py
@@ -9,7 +9,7 @@ import sys
 import langchain
 
 
-examples = [
+default_examples = [
     dict(
         query='find the chef with the most friends',
         nodes=pd.DataFrame(dict(
@@ -34,7 +34,7 @@ examples = [
         ), index=[2]),
     ),
     dict(
-        query='goats that jump the highest',
+        query='longest running friendships',
         nodes=pd.DataFrame(dict(
             id=[7, 99, 8],
             species=['goat', 'sheep', 'donkey'],
@@ -43,14 +43,24 @@ examples = [
         edges=pd.DataFrame(dict(
             src=[0, 1, 2],
             dst=[1, 2, 3],
+            start_date=[1999, 2012, 2013],
         )),
-        output_schema='id: str, jump_height: int',
+        output_schema='animal_a: str, animal_b: str, friendship_years: int',
         solution='''
-  goats = nodes[nodes['species'] == 'goat']
-  return goats.nlargest(10, 'jump_height')
+  current_date = 2023
+  edges['friendship_years'] = current_date - edges['start_date']
+  # Convert the IDs to string.
+  edges['animal_a'] = edges['src'].astype(str)
+  edges['animal_b'] = edges['dst'].astype(str)
+  return edges.nlargest(10, 'friendship_years')
         '''.strip(),
         expected_result=pd.DataFrame(dict(
-            id=[7], species=['goat'], jump_height=[13.5],
+            src=[0, 1, 2],
+            dst=[1, 2, 3],
+            start_date=[1999, 2012, 2013],
+            friendship_years=[24, 11, 10],
+            animal_a=['0', '1', '2'],
+            animal_b=['1', '2', '3'],
         )),
     ),
     dict(
@@ -142,6 +152,11 @@ You need to write a function `compute_from_graph(nodes, edges)` for the followin
 The function should return a DataFrame with columns: {output_schema}
 '''.strip()
 
+variation_template = '''
+Change `compute_from_graph(nodes, edges)` to perform the following task:
+- {query}
+'''.strip()
+
 answer_template = '''
 ```python
 def compute_from_graph(nodes, edges):
@@ -171,7 +186,7 @@ def check_examples(examples):
     assert (res.equals(e['expected_result'])), str(res)
 
 
-check_examples(examples)
+check_examples(default_examples)
 
 
 def openai(messages):
@@ -191,30 +206,53 @@ def cleanup(df):
   return df
 
 
-def pandas_on_graph(*, nodes, edges, query, output_schema):
+def human_msg(content):
+  return langchain.schema.HumanMessage(content=content)
+
+
+def ai_msg(content):
+  return langchain.schema.AIMessage(content=content)
+
+
+def pandas_on_graph(*, nodes, edges, query, output_schema, examples=None):
   nodes = cleanup(nodes)
   edges = cleanup(edges)
   pd.options.display.max_rows = 3 if len(nodes.columns) > 5 or len(edges.columns) > 5 else 10
   pd.options.display.max_columns = 100
   pd.options.display.width = 1000
 
-  messages = list(itertools.chain.from_iterable(
-      [
-          langchain.schema.HumanMessage(content=question_template.format(**e)),
-          langchain.schema.AIMessage(content=answer_template.format(**e)),
-      ]
-      for e in examples))
-  messages.append(langchain.schema.HumanMessage(
-      content=question_template.format(nodes=nodes, edges=edges, query=query, output_schema=output_schema)))
+  if examples:
+    # Use the provided examples. They have the same data and schema, so we only include them in the first message.
+    messages = [
+        human_msg(question_template.format(nodes=nodes, edges=edges,
+                  query=examples[0][0], output_schema=output_schema)),
+        ai_msg(answer_template.format(query=examples[0][0], solution=examples[0][1].strip())),
+        *itertools.chain.from_iterable(
+            [
+                human_msg(variation_template.format(query=e[0])),
+                ai_msg(answer_template.format(query=e[0], solution=e[1].strip())),
+            ]
+            for e in examples[1:]),
+        human_msg(variation_template.format(query=query)),
+    ]
+  else:
+    # Use the default examples. Include the full prompt each time because they have different data and schemas.
+    messages = [
+        *itertools.chain.from_iterable(
+            [
+                human_msg(question_template.format(**e)),
+                ai_msg(answer_template.format(**e)),
+            ]
+            for e in default_examples),
+        human_msg(question_template.format(nodes=nodes, edges=edges,
+                                           query=query, output_schema=output_schema))
+    ]
   msg = openai(messages)
   df = run_code(nodes=nodes, edges=edges, code=get_code(msg.content))
   if matches_schema(df, output_schema):
     return df
   messages.append(msg)
-  messages.append(
-      langchain.schema.HumanMessage(
-          content='Make sure the result has these columns: ' +
-          output_schema))
+  messages.append(human_msg('Make sure the result has these columns: ' + output_schema))
   msg = openai(messages)
   return run_code(nodes=nodes, edges=edges, code=get_code(msg.content))
 
@@ -232,8 +270,32 @@ def matches_schema(df, schema):
 
 
 if __name__ == '__main__':
-  d = dict(examples[0])
+  d = dict(default_examples[0])
   print(pandas_on_graph(
       nodes=d['nodes'], edges=d['edges'],
       query=sys.argv[1] if len(sys.argv) > 1 else d['query'],
-      output_schema=d['output_schema']))
+      output_schema='name: str, count: int',
+      examples=[
+    ('find the chef with the most friends',
+     '''
+  nodes = nodes[nodes['job'] == 'chef']
+  edges = edges[edges['relationship'] == 'friends']
+  nodes['count'] = edges.groupby('src').size()
+  return nodes.nlargest(1, 'count')
+     '''),
+    ('find the violinist with the least enemies',
+     '''
+  nodes = nodes[nodes['job'] == 'violinist']
+  edges = edges[edges['relationship'] == 'enemies']
+  nodes['count'] = edges.groupby('src').size()
+  return nodes.nsmallest(1, 'count')
+     '''),
+    ('the three athletes that have the most fans',
+     '''
+  nodes = nodes[nodes['job'] == 'athlete']
+  edges = edges[edges['relationship'] == 'fan']
+  nodes['count'] = edges.groupby('dst').size()
+  return nodes.nlargest(3, 'count')
+     '''),
+      ],
+    ))


### PR DESCRIPTION
If I run `python python/llm_pandas_on_graph.py 'the three most popular actors and athletes'` it's pretty good:

````
Change `compute_from_graph(nodes, edges)` to perform the following task:
- the three athletes that have the most fans 
````
````
```python
def compute_from_graph(nodes, edges):
  """the three athletes that have the most fans"""
  nodes = nodes[nodes['job'] == 'athlete']
  edges = edges[edges['relationship'] == 'fan']
  nodes['count'] = edges.groupby('dst').size()
  return nodes.nlargest(3, 'count')
```
````
````
Change `compute_from_graph(nodes, edges)` to perform the following task:
- the three most popular actors and athletes 
````
````
```python
def compute_from_graph(nodes, edges):
  """the three most popular actors and athletes"""
  nodes = nodes[(nodes['job'] == 'actor') | (nodes['job'] == 'athlete')]
  edges = edges[edges['relationship'] == 'fan']
  nodes['count'] = edges.groupby('dst').size()
  return nodes.nlargest(3, 'count')
```
````

That's great!

But on the airlines demo it still doesn't get it, despite a generous example:

````
Change `compute_from_graph(nodes, edges)` to perform the following task:
- airports within 200 km of Singapore
````
````
```python
def compute_from_graph(nodes, edges):
  """airports within 200 km of Singapore"""
  edges = edges.merge(nodes.add_suffix('_src'), left_on='src', right_index=True)
  edges = edges.merge(nodes.add_suffix('_dst'), left_on='dst', right_index=True)
  edges = edges.query('distance_km < 200 and city_dst = "Singapore"')
  return pd.DataFrame({'airport': set(edges.airport_src)})
```
````
````
Change `compute_from_graph(nodes, edges)` to perform the following task:
- the airports within 100 km of London
````
````
```python
from geopy.distance import geodesic

def compute_from_graph(nodes, edges):
  """airports within 100 km of London"""
  london = nodes[nodes['city'] == 'London']
  london_coords = (london['lat'].iloc[0], london['long'].iloc[0])
  airports = []
  for _, row in nodes.iterrows():
    coords = (row['lat'], row['long'])
    if geodesic(london_coords, coords).km < 100:
      airports.append(row['airport'])
  return pd.DataFrame({'airport': airports})
```
````

Even though I just used `distance_km` in the `airports within 200 km of Singapore` example, it still wants to use `geopy` for `airports within 100 km of London`. Oh well!