### PR TITLE
Fix Python test to be compatible with Pandas 2.0.0

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -52,7 +52,7 @@ dependencies:
 # For R API and tools.
 - r
 - r-essentials
-- r-arrow
+- r-arrow==10.0.1 # 11.0.0 isn't built with dataset support.
 - r-htmlwidgets
 - r-openssl
 - r-plotly

--- a/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/ComputeInPythonTest.scala
@@ -51,7 +51,7 @@ graph_attributes.average_age = vs.age.mean()
           "inputs" -> "vs.age",
           "outputs" -> "vs.v: np.ndarray",
           "code" -> """
-v = np.array([[1, 2]]) * vs.age[:, None]
+v = np.array([[1, 2]]) * vs.age.to_numpy()[:, None]
 vs['v'] = v.tolist()
           """),
       )


### PR DESCRIPTION
Fixes the failure seen on #379:

```
ValueError: Multi-dimensional indexing (e.g. `obj[:, None]`) is no longer supported.
Convert to a numpy array before indexing instead.
```