### PR TITLE
Suggest hard reloading if the JavaScript doesn't load

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -8,7 +8,9 @@
     <link rel="icon" type="image/png" href="favicon.png">
   </head>
   <body>
-    <div ng-view></div>
+    <div ng-view>
+      Loading LynxKite... Stuck? Try clearing the cache and reloading. Or contact us at lynxkite@lynxkite.com.
+    </div>
     <top-alerts></top-alerts>
     <script type="module" src="/index.js"></script>
   </body>


### PR DESCRIPTION
It's hard to reproduce the issue! I'll take a closer look if I hit it next time.

After pushing a new version, if you load everything from cache, that should work fine. If you have a cache miss on index.html, you get the links to the new js/css files. So you will download them too and everything will be fine. The only failure mode I can think of is that you take index.html from the cache, try to load the old js/css but don't have _that_ cached, so you go to the server and get 404s. That doesn't sound like something that we would hit with every update, right?

I've managed to reproduce it this way, and the message in this PR appears. (But you get 303s instead of 404s because we try to redirect to something.)