### PR TITLE
Update PartitionedParquet code for SPARK-40113

### DIFF
--- a/app/com/lynxanalytics/biggraph/partitioned_parquet/PartitionedParquet.scala
+++ b/app/com/lynxanalytics/biggraph/partitioned_parquet/PartitionedParquet.scala
@@ -58,7 +58,7 @@ class PartitionedParquetScanBuilder(
     dataSchema: StructType,
     options: CaseInsensitiveStringMap)
     extends ParquetScanBuilder(sparkSession, fileIndex, schema, dataSchema, options) {
-  override def build(): Scan = {
+  override def build(): ParquetScan = {
     new PartitionedParquetScan(
       sparkSession,
       hadoopConf,
@@ -66,7 +66,7 @@ class PartitionedParquetScanBuilder(
       dataSchema,
       readDataSchema(),
       readPartitionSchema(),
-      pushedParquetFilters,
+      pushedDataFilters,
       options)
   }
 }


### PR DESCRIPTION
This is @lacca0's change from another repo. [SPARK-40113](https://github.com/apache/spark/commit/cee30cb4994b178f6999cbbefdcaac21f0d60915) is coming in Spark 3.4.0 but it's already part of the Databricks runtime. I don't think there's any harm in this change. When used with Spark 3.3.0 it may break some pushed filters, but I don't think we rely on those. At least the tests pass!

(Still, let's not merge it before the release.)
