### PR TITLE
Fix tables in chroot

### DIFF
--- a/web/app/scripts/workspace/op-editor.js
+++ b/web/app/scripts/workspace/op-editor.js
@@ -21,7 +21,9 @@ angular.module('biggraph')
       },
       link: function(scope) {
         scope.$watch('boxMeta.description', function() {
-          scope.descriptionMarkdown = md.render(scope.boxMeta.description);
+          if (scope.boxMeta?.description) {
+            scope.descriptionMarkdown = md.render(scope.boxMeta.description);
+          }
         });
       },
     };


### PR DESCRIPTION
For #388. _This_ was the real issue in the current case. The distance from the issue to the error message is ridiculous.

To be fair, the Python process only printed this before dying with exit code 134:

```
s2n_init() failed: 335544378 (handshake was cancelled)
Fatal error condition occurred in /home/conda/feedstock_root/build_artifacts/aws-c-io_1679650583274/work/source/s2n/s2n_tls_channel_handler.c:203: 0 && "s2n_init() failed"
Exiting Application
No call stack information available
```

And #388 is not entirely correct. Retrying worked. Sphynx doesn't report the entity as existing because it's not there.

Adding lots of prints narrowed it down to `df.to_pandas()` in our `util.py` which triggers an `import pyarrow.parquet` line in Pandas which triggers `initialize_s3()` in [`pyarrow/fs.py`](https://github.com/apache/arrow/blob/apache-arrow-10.0.1/python/pyarrow/fs.py#L61). That calls native code, but `strace` showed it trying to open `/dev/urandom` before the errors.

So mounting `/dev/urandom` makes PyArrow work and we can write out the tables.

The JavaScript change just gets rid of an error in the console.