### PR TITLE
Fix context menu closing

### DIFF
--- a/web/app/scripts/util/context-menu.js
+++ b/web/app/scripts/util/context-menu.js
@@ -13,7 +13,7 @@ angular.module('biggraph').directive('contextMenu', ['$timeout', function($timeo
         if (enabled) {
           // Whenever the menu opens we set focus on it. We need this so we can close it on blur
           // (that is, if the user mouse downs anywhere outside).
-          $timeout(function() { element.focus(); });
+          $timeout(() => element.find('.context-menu').focus());
         }
       });
       scope.executeAction = function(action) {


### PR DESCRIPTION
Gabor Benedek reported the issue that the visualization context menu no longer closes when you click outside of it.

https://github.com/lynxkite/lynxkite/commit/276b8304c16e1c24406c41d1109ebdbe34d48c34 removed the `replace: true` setting. `element` used to point at the root node of the template HTML. But without `replace: true` it points to a container element, that can't be focused. If the element is not focused, it won't be un-focused when you click outside, and we won't close it.

I don't remember why `replace: true` had to go, but it's fine. We can just be more specific about what we want to focus.