### PR TITLE
Make ScalaScriptSecurityManager optional

### DIFF
--- a/app/com/lynxanalytics/biggraph/scala_sandbox/ScalaScript.scala
+++ b/app/com/lynxanalytics/biggraph/scala_sandbox/ScalaScript.scala
@@ -29,8 +29,10 @@ object ScalaScriptSecurityManager {
 class ScalaScriptSecurityManager extends SecurityManager {
 
   val shouldCheck = new DynamicVariable[Boolean](false)
+  val securityEnabled = Environment.envOrElse("KITE_DERIVE_SECURITY_MANAGER", "enabled") == "enabled"
+
   def checkedRun[R](op: => R): R = {
-    shouldCheck.withValue(true) {
+    shouldCheck.withValue(securityEnabled) {
       op
     }
   }


### PR DESCRIPTION
For #380. Because SecurityManager has been removed from Java (https://github.com/lynxkite/lynxkite/issues/265) I think making this optional is a reasonable step. For single-user and read-only deployments there is no harm in turning it off. For multi-user environments this will let us explore alternative solutions.