### PR TITLE
Allow specifying the database for Neo4j import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Please add changes to "master", preferably ordered by their significance. (Most 
 
 ### master
 
+- Added a _database_ parameter for Neo4j import and export boxes. [#404](https://github.com/lynxkite/lynxkite/pull/404)
+- Fixed an issue with S3 access. [#402](https://github.com/lynxkite/lynxkite/pull/402)
+
 ### 5.3.0
 
 - Upgraded to Apache Spark 3.3.2. [#369](https://github.com/lynxkite/lynxkite/pull/369)

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ExportOperations.scala
@@ -180,6 +180,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
       Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
       Param("username", "Neo4j username", defaultValue = "neo4j"),
       Param("password", "Neo4j password", defaultValue = "neo4j"),
+      Param("database", "Neo4j database", placeholder = "Leave empty to use the default database."),
       NonNegInt("version", "Export repetition ID", default = 1),
     )
     lazy val project = projectInput("graph")
@@ -205,6 +206,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
         params("url"),
         params("username"),
         params("password"),
+        params("database"),
         params("labels"),
         keys,
         params("version").toInt,
@@ -272,6 +274,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
         Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
         Param("username", "Neo4j username", defaultValue = "neo4j"),
         Param("password", "Neo4j password", defaultValue = "neo4j"),
+        Param("database", "Neo4j database", placeholder = "Leave empty to use the default database."),
         NonNegInt("version", "Export repetition ID", default = 1),
         Choice(
           "node_labels",
@@ -304,6 +307,7 @@ class ExportOperations(env: SparkFreeEnvironment) extends OperationRegistry {
           params("url"),
           params("username"),
           params("password"),
+          params("database"),
           params("node_labels"),
           params("relationship_type"),
           params("version").toInt)

--- a/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
+++ b/app/com/lynxanalytics/biggraph/frontend_operations/ImportOperations.scala
@@ -172,6 +172,7 @@ class ImportOperations(env: SparkFreeEnvironment) extends ProjectOperations(env)
       Param("url", "Neo4j connection", defaultValue = "bolt://localhost:7687"),
       Param("username", "Neo4j username", defaultValue = "neo4j"),
       Param("password", "Neo4j password", defaultValue = "neo4j"),
+      Param("database", "Neo4j database", placeholder = "Leave empty to use default database."),
       Code("vertex_query", "Vertex query", defaultValue = "MATCH (node) RETURN node", language = ""),
       Code("edge_query", "Edge query", defaultValue = "MATCH ()-[rel]->() RETURN rel", language = ""),
       ImportedDataParam(),
@@ -208,6 +209,7 @@ class ImportOperations(env: SparkFreeEnvironment) extends ProjectOperations(env)
           .option("authentication.type", "basic")
           .option("authentication.basic.username", params("username"))
           .option("authentication.basic.password", params("password"))
+          .option("database", params("database"))
           .option("url", params("url"))
           .option("schema.strategy", "string")
           .option("query", query)

--- a/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-edge-attributes-to-neo4j.asciidoc
@@ -29,6 +29,9 @@ Username for the connection.
 Password for the connection. It will be saved in the workspace and visible to anyone with
 access to the workspace.
 
+[p-database]#Neo4j database#::
+If the Neo4j server has multiple databases, you can specify which one to write to.
+
 [p-version]#Export repetition ID#::
 LynxKite only re-computes outputs if parameters or inputs have changed.
 This is true for exports too. If you want to repeat a previous export, you can increase this

--- a/web/app/help/operations/export-graph-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-graph-to-neo4j.asciidoc
@@ -41,6 +41,9 @@ Username for the connection.
 Password for the connection. It will be saved in the workspace and visible to anyone with
 access to the workspace.
 
+[p-database]#Neo4j database#::
+If the Neo4j server has multiple databases, you can specify which one to write to.
+
 [p-version]#Export repetition ID#::
 LynxKite only re-computes outputs if parameters or inputs have changed.
 This is true for exports too. If you want to repeat a previous export, you can increase this

--- a/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
+++ b/web/app/help/operations/export-vertex-attributes-to-neo4j.asciidoc
@@ -29,6 +29,9 @@ Username for the connection.
 Password for the connection. It will be saved in the workspace and visible to anyone with
 access to the workspace.
 
+[p-database]#Neo4j database#::
+If the Neo4j server has multiple databases, you can specify which one to write to.
+
 [p-version]#Export repetition ID#::
 LynxKite only re-computes outputs if parameters or inputs have changed.
 This is true for exports too. If you want to repeat a previous export, you can increase this

--- a/web/app/help/operations/import-from-neo4j.asciidoc
+++ b/web/app/help/operations/import-from-neo4j.asciidoc
@@ -23,6 +23,8 @@ The connection URI for Neo4j.
 The username to use for the connection.
 [p-password]#Neo4j password#::
 The password to use for the connection.
+[p-database]#Neo4j database#::
+If the Neo4j server has multiple databases, you can specify which one to read from.
 [p-vertex_query]#Vertex query#::
 The Cypher query to run on Neo4j to get the vertices. This query must return a node named `node`.
 The default query imports all the nodes from Neo4j. Leave empty to not import vertex attributes.


### PR DESCRIPTION
For https://github.com/lynxkite/lynxkite/discussions/113.

The Neo4j Spark connector [documentation](https://neo4j.com/docs/spark/current/configuration/) says "The driver allows to define the database in the URL [...]". But doesn't specify how! I only see `/db/xxx` in old examples and it's reportedly not working. So let's go with the new parameter.