### PR TITLE
Allow KITE_DRAWING_OVERALL to take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please add changes to "master", preferably ordered by their significance. (Most 
 
 ### master
 
+- `KITE_DRAWING_OVERALL` now properly controls the limits on the size of visualizations. [#410](https://github.com/lynxkite/lynxkite/pull/410)
+
 ### 5.3.1
 
 - Added a _database_ parameter for Neo4j import and export boxes. [#404](https://github.com/lynxkite/lynxkite/pull/404)

--- a/app/com/lynxanalytics/biggraph/controllers/GraphDrawingController.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/GraphDrawingController.scala
@@ -55,7 +55,7 @@ case class VertexDiagramSpec(
     attrs: Seq[String] = Seq(),
     radius: Int = 1,
     // Now ignored. Kept for compatibility.
-    maxSize: Int = DrawingThresholds.MaxSampledViewVertices)
+    maxSize: Option[Int] = None)
 
 case class FEVertex(
     // For bucketed view:
@@ -114,7 +114,7 @@ case class EdgeDiagramSpec(
     // works for small edge set visualizations (i.e. sampled mode).
     attrs: Seq[AggregatedAttribute] = Seq(),
     // Now ignored. Kept for compatibility.
-    maxSize: Int = DrawingThresholds.MaxSampledViewEdges)
+    maxSize: Option[Int] = None)
 
 case class BundleSequenceStep(bundle: String, reversed: Boolean)
 

--- a/app/com/lynxanalytics/biggraph/controllers/GraphDrawingController.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/GraphDrawingController.scala
@@ -53,7 +53,9 @@ case class VertexDiagramSpec(
     // Edge bundle used to find neighborhood of the central vertex.
     sampleSmearEdgeBundleId: String = "",
     attrs: Seq[String] = Seq(),
-    radius: Int = 1)
+    radius: Int = 1,
+    // Now ignored. Kept for compatibility.
+    maxSize: Int = DrawingThresholds.MaxSampledViewVertices)
 
 case class FEVertex(
     // For bucketed view:
@@ -110,7 +112,9 @@ case class EdgeDiagramSpec(
     // Attributes to be returned together with the edges. As one visualized edge can correspond to
     // many actual edges, clients always have to specify an aggregator as well. For now, this only
     // works for small edge set visualizations (i.e. sampled mode).
-    attrs: Seq[AggregatedAttribute] = Seq())
+    attrs: Seq[AggregatedAttribute] = Seq(),
+    // Now ignored. Kept for compatibility.
+    maxSize: Int = DrawingThresholds.MaxSampledViewEdges)
 
 case class BundleSequenceStep(bundle: String, reversed: Boolean)
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,6 @@ libraryDependencies ++= Seq(
   "org.mindrot" % "jbcrypt" % "0.3m",  // For password hashing.
   "org.scalatest" %% "scalatest" % "3.2.7" % "test",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  // For accessing S3 fs from local instance.
-  "org.apache.hadoop" % "hadoop-aws" % "3.3.4" excludeAll(
-    // But we still want to take Hadoop from Spark.
-    ExclusionRule(organization = "org.apache.hadoop", name = "hadoop-common")),
   "net.java.dev.jets3t" % "jets3t" % "0.9.4",
   // Provides HyperLogLogPlus counters. Must be the same version that is
   // used by Spark.

--- a/dependency-licenses/scala.md
+++ b/dependency-licenses/scala.md
@@ -26,10 +26,8 @@ Apache | [Apache 2.0](https://opensource.org/licenses/Apache-2.0) | io.grpc # gr
 Apache | [Apache 2.0](https://opensource.org/licenses/Apache-2.0) | io.perfmark # perfmark-api # 0.25.0 | <notextile></notextile>
 Apache | [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0) | net.java.dev.jets3t # jets3t # 0.9.4 | <notextile></notextile>
 Apache | [Apache License V2.0](https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE.txt) | com.google.flatbuffers # flatbuffers-java # 1.12.0 | <notextile></notextile>
-Apache | [Apache License Version 2.0](http://repository.jboss.org/licenses/apache-2.0.txt) | org.wildfly.openssl # wildfly-openssl # 1.0.7.Final | <notextile></notextile>
 Apache | [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | net.java.dev.jna # jna # 5.5.0 | <notextile></notextile>
 Apache | [Apache License, Version 2](http://www.apache.org/licenses/LICENSE-2.0) | org.neo4j.driver # neo4j-java-driver # 4.2.5 | <notextile></notextile>
-Apache | [Apache License, Version 2.0](https://aws.amazon.com/apache2.0) | com.amazonaws # aws-java-sdk-bundle # 1.12.262 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.clearspring.analytics # stream # 2.9.6 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.google.cloud.spark # bigquery-connector-common # 0.25.2 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.google.cloud.spark # spark-2.4-bigquery-pushdown_2.12 # 0.25.2 | <notextile></notextile>
@@ -40,7 +38,6 @@ Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.google.cloud.spark # spark-bigquery_2.12 # 0.25.2 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.google.guava # guava # 31.1-jre | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0) | com.jamesmurty.utils # java-xmlbuilder # 1.1 | <notextile></notextile>
-Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-codec # commons-codec # 1.15 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-io # commons-io # 2.6 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-net # commons-net # 3.6 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0) | io.jsonwebtoken # jjwt # 0.9.1 | <notextile></notextile>
@@ -89,7 +86,6 @@ Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-lang3 # 3.8 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-lang3 # 3.9 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-text # 1.7 | <notextile></notextile>
-Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.hadoop # hadoop-aws # 3.3.4 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.httpcomponents # httpclient # 4.5.13 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.httpcomponents # httpcore # 4.4.15 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.httpcomponents # httpmime # 4.5.9 | <notextile></notextile>
@@ -138,6 +134,7 @@ Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typ
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # play-test_2.12 # 2.8.19 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # play_2.12 # 2.8.19 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # twirl-api_2.12 # 1.5.1 | <notextile></notextile>
+Apache | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-codec # commons-codec # 1.16.0 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) | io.delta # delta-core_2.12 # 2.1.0 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) | io.delta # delta-storage # 2.1.0 | <notextile></notextile>
 Apache | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | org.scala-lang # scala-compiler # 2.12.13 | <notextile></notextile>

--- a/web/app/scripts/project/load-graph.js
+++ b/web/app/scripts/project/load-graph.js
@@ -47,7 +47,6 @@ angular.module('biggraph').factory('loadGraph', ['util', function (util) {
           layout3D: viewData.display === '3d',
           relativeEdgeDensity: viewData.relativeEdgeDensity,
           attrs: edgeAttrs,
-          maxSize: (viewData.display === '3d') ? 1000000 : 10000,
         });
       }
       const vertexAttrs = [];
@@ -78,7 +77,6 @@ angular.module('biggraph').factory('loadGraph', ['util', function (util) {
         centralVertexIds: viewData.centers,
         sampleSmearEdgeBundleId: (viewData.edgeBundle || { id: '' }).id,
         attrs: vertexAttrs,
-        maxSize: (viewData.display === '3d') ? 1000000 : 10000,
       });
     }
 
@@ -95,7 +93,6 @@ angular.module('biggraph').factory('loadGraph', ['util', function (util) {
           layout3D: false,
           relativeEdgeDensity: false,
           attrs: [],
-          maxSize: 10000,
         });
       }
       if (rightToLeftBundle !== undefined) {
@@ -110,7 +107,6 @@ angular.module('biggraph').factory('loadGraph', ['util', function (util) {
           layout3D: false,
           relativeEdgeDensity: false,
           attrs: [],
-          maxSize: 10000,
         });
       }
     }


### PR DESCRIPTION
Turns out `KITE_DRAWING_OVERALL` was setting a default visualization size limit, but the frontend was overriding it with a fixed 10,000. 😮‍💨 This change removes the special casing for the 3D view, but I think that's not too bad. You can configure the limit after all!