### PR TITLE
Skip color legend if long, fix CI issues

### DIFF
--- a/.github/workflows/earthly-test.yml
+++ b/.github/workflows/earthly-test.yml
@@ -125,21 +125,15 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        root-reserve-mb: 512
-        swap-size-mb: 1024
-        remove-dotnet: 'true'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0'
+      uses: 'google-github-actions/auth@v2'
       with:
         workload_identity_provider: 'projects/422846954881/locations/global/workloadIdentityPools/github-actions/providers/github'
         service_account: 'github-actions@external-lynxkite.iam.gserviceaccount.com'
         token_format: 'access_token'
-    - uses: 'docker/login-action@v2'
+    - uses: 'docker/login-action@v3'
       with:
         registry: 'us-central1-docker.pkg.dev'
         username: 'oauth2accesstoken'
@@ -154,14 +148,14 @@ jobs:
         fi
         git checkout -b "$branch" || true
     - name: Download latest earthly
-      run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.30/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
     - name: Earthly version
       run: earthly --version
     - name: Run frontend test
       run: earthly --remote-cache=us-central1-docker.pkg.dev/external-lynxkite/github-actions-us/earthly:cache +frontend-test
     - name: Save test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: frontend-test-results
         path: playwright-report.zip

--- a/.github/workflows/earthly-test.yml
+++ b/.github/workflows/earthly-test.yml
@@ -125,6 +125,12 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
     - uses: actions/checkout@v3
     - id: 'auth'
       name: 'Authenticate to Google Cloud'

--- a/Earthfile
+++ b/Earthfile
@@ -91,6 +91,8 @@ backend-test-docker:
 
 backend-test-sphynx:
   FROM +app-build
+  # Install extra dependencies, like PyTorch.
+  RUN ./conda-env.sh build python > env.yml && micromamba install -y -n base -f env.yml
   COPY .scalafmt.conf .
   COPY tools/wait_for_port.sh tools/
   COPY test test
@@ -159,7 +161,7 @@ frontend-test:
 docker:
   FROM mambaorg/micromamba:jammy
   COPY conda-env.* .
-  RUN ./conda-env.sh > env.yml && micromamba install -y -n base -f env.yml
+  RUN ./conda-env.sh python > env.yml && micromamba install -y -n base -f env.yml
   COPY +assembly/lynxkite.jar .
   COPY conf/kiterc_template .
   CMD ["bash", "-c", ". kiterc_template && spark-submit lynxkite.jar"]

--- a/Earthfile
+++ b/Earthfile
@@ -146,7 +146,7 @@ frontend-test-save:
   RUN cd web && ../tools/with_lk.sh npx playwright test || touch failed
   # After running the tests we do a little dance to save the report even if the test failed.
   # https://github.com/earthly/earthly/issues/2452
-  RUN cd web && zip -qr playwright-report.zip playwright-report
+  RUN cd web && zip -mqr playwright-report.zip playwright-report
   SAVE ARTIFACT web/playwright-report.zip
 frontend-test-copy:
   LOCALLY

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -2,16 +2,18 @@
 # Generates smaller dependency lists based on conda-env.yml.
 # Usage:
 #
-#   conda-env.sh [build] [cuda]
+#   conda-env.sh [build] [cuda] [python]
 #
 # The "build" parameter causes build dependencies to be included.
 # The "cuda" parameter causes CUDA (GPU) dependencies to be included.
+# The "python" parameter causes Python run-time dependencies to be included.
 #
 # The generated config is printed on stdout.
 
 cd $(dirname $0)
 include_cuda='false'
 include_build='false'
+include_python_deps='false'
 while [[ $# -gt 0 ]]; do
   case $1 in
     'build')
@@ -19,6 +21,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     'cuda')
       include_cuda='true'
+      ;;
+    'python')
+      include_python_deps='true'
       ;;
   esac
   shift
@@ -28,6 +33,9 @@ if [[ $include_build == 'false' ]]; then
   cfg=$(echo "$cfg" | grep -Pv -- '^#|- (make|sbt|nodejs|go|compilers|swig|autopep8|mypy|zip|wget)\b')
 fi
 if [[ $include_cuda == 'false' ]]; then
-  cfg=$(echo "$cfg" | grep -Pv -- '- (rapidsai|nvidia|cugraph|cudatoolkit|pytorch|pyg)\b' | sed 's/cuda\|cu113/cpu/g')
+  cfg=$(echo "$cfg" | grep -Pv -- '- (rapidsai|nvidia|cugraph|cudatoolkit)\b' | sed 's/cuda\|cu113/cpu/g')
+fi
+if [[ $include_python_deps == 'false' ]]; then
+  cfg=$(echo "$cfg" | grep -Pv -- '- (pytorch|pyg)\b')
 fi
 echo "$cfg"

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -28,6 +28,6 @@ if [[ $include_build == 'false' ]]; then
   cfg=$(echo "$cfg" | grep -Pv -- '^#|- (make|sbt|nodejs|go|compilers|swig|autopep8|mypy|zip|wget)\b')
 fi
 if [[ $include_cuda == 'false' ]]; then
-  cfg=$(echo "$cfg" | grep -Pv -- '- (rapidsai|nvidia|cugraph|cudatoolkit)\b' | sed 's/cuda\|cu113/cpu/g')
+  cfg=$(echo "$cfg" | grep -Pv -- '- (rapidsai|nvidia|cugraph|cudatoolkit|pytorch|pyg)\b' | sed 's/cuda\|cu113/cpu/g')
 fi
 echo "$cfg"

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -28,15 +28,15 @@ dependencies:
 - libnetworkit==10.0
 - libtlx==0.5.20200222
 # For Python and ML.
-- python==3.10
+- python==3.10.*
 - numpy
 - pandas
 - scikit-learn
 - pyarrow
 - cudatoolkit==11.3.1
 - cugraph
-- pytorch::pytorch==1.11.0=*cuda*
-- pyg==2.0.4=*cu113*
+- pytorch::pytorch==1.13.1=*cuda*
+- pyg==2.2.0=*cu113*
 - matplotlib
 - openai
 - langchain

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -28,7 +28,7 @@ dependencies:
 - libnetworkit==10.0
 - libtlx==0.5.20200222
 # For Python and ML.
-- python>=3.8
+- python==3.10
 - numpy
 - pandas
 - scikit-learn

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -2,6 +2,9 @@
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+       <level>ERROR</level>
+     </filter>
      <encoder>
          <!-- We should replace all occurrences of SECRET(...) in both message and exception.
          But then logback does not realize that the exception was in fact logged, and attaches the

--- a/test/com/lynxanalytics/biggraph/frontend_operations/LogisticRegressionTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/LogisticRegressionTest.scala
@@ -41,8 +41,6 @@ class LogisticRegressionTest extends OperationsTestBase {
     val probabilityOf1 =
       project.vertexAttributes("classification_probability_of_1").runtimeSafeCast[Double]
     val probabilityOf1Map = probabilityOf1.rdd.collect.toMap
-
-    // Example graph age: 0 -> 20.3, 1 -> 18.2, 2 -> 50.3, 3 -> 2.
     var class1 = 0
     classificationMap.foreach {
       case (id, cl) => {

--- a/test/com/lynxanalytics/biggraph/frontend_operations/LogisticRegressionTest.scala
+++ b/test/com/lynxanalytics/biggraph/frontend_operations/LogisticRegressionTest.scala
@@ -5,16 +5,17 @@ import com.lynxanalytics.biggraph.graph_api.GraphTestUtils._
 
 class LogisticRegressionTest extends OperationsTestBase {
   test("train and score a logistic regression") {
-    val project = box("Create example graph")
+    val project = box("Create vertices", Map("size" -> "100"))
+      .box("Add random vertex attribute") // Uses a fixed seed, so the test is deterministic.
       .box(
         "Derive vertex attribute",
-        Map("output" -> "label", "expr" -> "if (age > 30) 1.0 else 0.0"))
+        Map("output" -> "label", "expr" -> "if (random > 0.5) 1.0 else 0.0"))
       .box(
         "Train a logistic regression model",
         Map(
           "name" -> "model",
           "label" -> "label",
-          "features" -> "age",
+          "features" -> "random",
           "max_iter" -> "5",
           "elastic_net_param" -> "0.8",
           "reg_param" -> "0.3"),
@@ -27,7 +28,7 @@ class LogisticRegressionTest extends OperationsTestBase {
             "modelName" : "model",
             "isClassification" : true,
             "generatesProbability" : true,
-            "features" : ["age"]}""",
+            "features" : ["random"]}""",
         ),
       ).project
     val classification = project.vertexAttributes("classification").runtimeSafeCast[Double]
@@ -42,10 +43,10 @@ class LogisticRegressionTest extends OperationsTestBase {
     val probabilityOf1Map = probabilityOf1.rdd.collect.toMap
 
     // Example graph age: 0 -> 20.3, 1 -> 18.2, 2 -> 50.3, 3 -> 2.
-    assert(classificationMap == Map(0 -> 0.0, 1 -> 0.0, 2 -> 1.0, 3 -> 0.0))
-    assert(certaintyMap(3) > certaintyMap(1) && certaintyMap(1) > certaintyMap(0))
-    classificationMap.map {
+    var class1 = 0
+    classificationMap.foreach {
       case (id, cl) => {
+        class1 += cl.toInt
         if (cl == 0) {
           assert(certaintyMap(id) == probabilityOf0Map(id))
         } else {
@@ -54,5 +55,6 @@ class LogisticRegressionTest extends OperationsTestBase {
         assert(probabilityOf0Map(id) + probabilityOf1Map(id) == 1)
       }
     }
+    assert(30 < class1 && class1 < 70)
   }
 }

--- a/web/app/scripts/project/graph-view.js
+++ b/web/app/scripts/project/graph-view.js
@@ -585,8 +585,10 @@ angular.module('biggraph').directive('graphView', ['util', '$compile', '$timeout
 
   Vertices.prototype.addColorLegend = function(colorMap, title) {
     this.addLegendLine(title);
-    for (let attr in colorMap) {
-      this.addLegendLine(attr || 'undefined', 20).color = colorMap[attr] || UNCOLORED;
+    if (Object.keys(colorMap).length <= 24) {
+      for (let attr in colorMap) {
+        this.addLegendLine(attr || 'undefined', 20).color = colorMap[attr] || UNCOLORED;
+      }
     }
   };
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -37,7 +37,7 @@
         "vega-lite": "^5.6.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.31.2",
+        "@playwright/test": "^1.43.0",
         "@types/node": "^18.15.0",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
@@ -1018,22 +1018,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
+      "integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright": "1.43.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "node": ">=16"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3200,16 +3196,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+    "node_modules/playwright": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
+      "integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
       "dev": true,
+      "dependencies": {
+        "playwright-core": "1.43.0"
+      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
+      "integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/prelude-ls": {
@@ -5192,14 +5206,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
+      "integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "fsevents": "2.3.2",
-        "playwright-core": "1.31.2"
+        "playwright": "1.43.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -6817,10 +6829,20 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "playwright": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
+      "integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.43.0"
+      }
+    },
     "playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
+      "integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
       "dev": true
     },
     "prelude-ls": {

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "vega-lite": "^5.6.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.2",
+    "@playwright/test": "^1.43.0",
     "@types/node": "^18.15.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -27,7 +27,6 @@ const config: PlaywrightTestConfig = {
       },
     },
   ],
-  outputDir: 'test-results/',
 };
 
 export default config;

--- a/web/tests/filter.spec.ts
+++ b/web/tests/filter.spec.ts
@@ -19,7 +19,7 @@ test.beforeAll(async ({ browser }) => {
 
 test('histograms after hard filters', async () => {
   const state = await workspace.openStateView('filter0', 'graph');
-  await expect(state.left.vertexCount).toHaveText('2');
+  await expect(state.left.vertexCount).toHaveText('2', { timeout: 30_000 });
   await expect(state.left.edgeCount).toHaveText('1');
   await state.left.vertexAttribute('name').expectHistogramValues([
     { title: 'Adam', size: 100, value: 1 },

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -51,9 +51,8 @@ export class Entity {
   }
 
   async popoff() {
-    if ((await this.element.count()) > 0) {
-      await angularEval(this.element, 'closeMenu()');
-    }
+    // Try to close the menu in case it is open. Not waiting for this.
+    angularEval(this.element, 'closeMenu()');
     await expect(this.menu).not.toBeVisible();
   }
 
@@ -708,7 +707,7 @@ class VisualizationState {
     await expect(async () => {
       const graph = await this.graphData();
       fn(graph);
-    }).toPass();
+    }).toPass({ timeout: 60_000 });
   }
 }
 
@@ -730,7 +729,7 @@ export class Splash {
       window.localStorage.setItem('entry-selector tutorial done', 'true');
       window.localStorage.setItem('allow data collection', 'false');
     });
-    await page.goto('/#/dir/');
+    await page.reload();
     await page.evaluate(() => {
       // Floating elements can overlap buttons and block clicks.
       document.styleSheets[0].insertRule('.spark-status, .user-menu { position: static !important; }');

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -52,7 +52,7 @@ export class Entity {
 
   async popoff() {
     // Try to close the menu in case it is open. Not waiting for this.
-    angularEval(this.element, 'closeMenu()');
+    void angularEval(this.element, 'closeMenu()');
     await expect(this.menu).not.toBeVisible();
   }
 

--- a/web/tests/lynxkite.ts
+++ b/web/tests/lynxkite.ts
@@ -51,8 +51,8 @@ export class Entity {
   }
 
   async popoff() {
-    // Try to close the menu in case it is open. Not waiting for this.
-    void angularEval(this.element, 'closeMenu()');
+    await expect(this.menu).toBeVisible();
+    await angularEval(this.element, 'closeMenu()');
     await expect(this.menu).not.toBeVisible();
   }
 
@@ -115,7 +115,6 @@ export class Entity {
   async clickMenu(id: string) {
     const p = await this.popup();
     await p.locator('#' + id).click();
-    await this.popoff();
   }
 }
 


### PR DESCRIPTION
I created CSS color strings in a Python box for the visualization in https://github.com/lynxkite/lynxkite/pull/414. The colors then end up in the legend, making it super long with 100+ nodes. So I added a cutoff. It looks nice:
<img width="466" alt="image" src="https://github.com/lynxkite/lynxkite/assets/1268018/e8598f2d-501e-4b3b-b89e-9068d720b416">
(Here the color is based on the first three dimensions of the embedding, while the first two are used as for layout.)