### PR TITLE
Rearrange Python dependencies

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -91,9 +91,10 @@ backend-test-docker:
 
 backend-test-sphynx:
   FROM +app-build
-  # Install extra dependencies, like PyTorch.
-  COPY python_requirements.txt .
+  COPY python_requirements*.txt .
   RUN pip install -r python_requirements.txt
+  RUN pip install --index-url https://download.pytorch.org/whl/cpu torch==2.3.*
+  RUN pip install torch_geometric==2.2.* torch-cluster torch-scatter torch-sparse
   COPY .scalafmt.conf .
   COPY tools/wait_for_port.sh tools/
   COPY test test
@@ -118,6 +119,8 @@ bash:
   RUN --interactive bash
 
 python-test:
+  COPY python_requirements.txt .
+  RUN pip install -r python_requirements.txt
   COPY tools/wait_for_port.sh tools/
   COPY tools/with_lk.sh tools/
   COPY +assembly/lynxkite.jar target/scala-2.12/lynxkite-0.1-SNAPSHOT.jar

--- a/Earthfile
+++ b/Earthfile
@@ -92,7 +92,8 @@ backend-test-docker:
 backend-test-sphynx:
   FROM +app-build
   # Install extra dependencies, like PyTorch.
-  RUN ./conda-env.sh build python > env.yml && micromamba install -y -n base -f env.yml
+  COPY python_requirements.txt .
+  RUN pip install -r python_requirements.txt
   COPY .scalafmt.conf .
   COPY tools/wait_for_port.sh tools/
   COPY test test
@@ -160,8 +161,8 @@ frontend-test:
 
 docker:
   FROM mambaorg/micromamba:jammy
-  COPY conda-env.* .
-  RUN ./conda-env.sh python > env.yml && micromamba install -y -n base -f env.yml
+  COPY python_requirements.txt .
+  RUN pip install -r python_requirements.txt
   COPY +assembly/lynxkite.jar .
   COPY conf/kiterc_template .
   CMD ["bash", "-c", ". kiterc_template && spark-submit lynxkite.jar"]

--- a/app/com/lynxanalytics/biggraph/controllers/Operation.scala
+++ b/app/com/lynxanalytics/biggraph/controllers/Operation.scala
@@ -242,6 +242,7 @@ object Operation {
                 val prefixes = Seq(s"$inputName.") ++ (if (inputs.size == 1) Seq("") else Seq())
                 prefixes.map(prefix => s"$prefix$tableName" -> proto)
             }
+          case (inputName, state) => throw new AssertionError(s"Invalid input for $inputName: $state")
         }
       }
     }

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -2,40 +2,24 @@
 # Generates smaller dependency lists based on conda-env.yml.
 # Usage:
 #
-#   conda-env.sh [build] [cuda] [python]
+#   conda-env.sh [build]
 #
 # The "build" parameter causes build dependencies to be included.
-# The "cuda" parameter causes CUDA (GPU) dependencies to be included.
-# The "python" parameter causes Python run-time dependencies to be included.
 #
 # The generated config is printed on stdout.
 
 cd $(dirname $0)
-include_cuda='false'
 include_build='false'
-include_python_deps='false'
 while [[ $# -gt 0 ]]; do
   case $1 in
     'build')
       include_build='true'
-      ;;
-    'cuda')
-      include_cuda='true'
-      ;;
-    'python')
-      include_python_deps='true'
       ;;
   esac
   shift
 done
 cfg=$(cat conda-env.yml)
 if [[ $include_build == 'false' ]]; then
-  cfg=$(echo "$cfg" | grep -Pv -- '^#|- (make|sbt|nodejs|go|compilers|swig|autopep8|mypy|zip|wget)\b')
-fi
-if [[ $include_cuda == 'false' ]]; then
-  cfg=$(echo "$cfg" | grep -Pv -- '- (rapidsai|nvidia|cugraph|cudatoolkit)\b' | sed 's/cuda\|cu113/cpu/g')
-fi
-if [[ $include_python_deps == 'false' ]]; then
-  cfg=$(echo "$cfg" | grep -Pv -- '- (pytorch|pyg)\b')
+  cfg=$(echo "$cfg" | grep -Pv -- '^#|- (make|sbt|nodejs|go|compilers|swig|zip|wget)\b')
 fi
 echo "$cfg"

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -1,10 +1,6 @@
 # The full list of Conda dependencies for building and running LynxKite.
 # For a more limited list please see conda-env.sh.
 channels:
-- rapidsai
-- pyg
-- nvidia
-- pytorch
 - conda-forge
 - r
 dependencies:
@@ -27,35 +23,12 @@ dependencies:
 - libstdcxx-ng
 - libnetworkit==10.0
 - libtlx==0.5.20200222
-# For Python and ML.
+# For ML.
 - python==3.10.*
-- numpy
-- pandas
-- scikit-learn
-- pyarrow
-- cudatoolkit==11.3.1
-- cugraph
-- pytorch::pytorch==1.13.1=*cuda*
-- pyg==2.2.0=*cu113*
-- matplotlib
-- openai
-- langchain
-# PyG dependencies get confused under Mamba.
-- pytorch-cluster=*=*cu113*
-- pytorch-scatter=*=*cu113*
-- pytorch-sparse=*=*cu113*
-- pytorch-spline-conv=*=*cu113*
-# For Python API and tools.
-- autopep8
-- mypy
-- ruamel.yaml
-- requests
-- typed-ast
-- types-requests
 # For R API and tools.
 - r
 - r-essentials
-- r-arrow==10.0.1 # 11.0.0 isn't built with dataset support.
+- r-arrow=
 - r-htmlwidgets
 - r-openssl
 - r-plotly

--- a/dependency-licenses/javascript.md
+++ b/dependency-licenses/javascript.md
@@ -1,7 +1,7 @@
 ├─ MIT: 200
 ├─ ISC: 59
 ├─ BSD-3-Clause: 54
-├─ Apache-2.0: 51
+├─ Apache-2.0: 52
 ├─ BSD-2-Clause: 14
 ├─ 0BSD: 2
 ├─ (CC-BY-4.0 AND OFL-1.1 AND MIT): 1

--- a/dependency-licenses/scala.md
+++ b/dependency-licenses/scala.md
@@ -2,7 +2,6 @@
 
 Category | License | Dependency | Notes
 --- | --- | --- | ---
-Apache | [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.lucene # lucene-core # 5.5.5 | <notextile></notextile>
 Apache | [Apache 2](https://www.apache.org/licenses/LICENSE-2.0) | org.conscrypt # conscrypt-openjdk-uber # 2.5.1 | <notextile></notextile>
 Apache | [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.fluentlenium # fluentlenium-core # 3.7.1 | <notextile></notextile>
 Apache | [Apache 2](http://www.apache.org/licenses/LICENSE-2.0) | org.scalaj # scalaj-http_2.12 # 2.4.2 | <notextile></notextile>
@@ -83,7 +82,6 @@ Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.arrow # arrow-vector # 7.0.0 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-compress # 1.20 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-exec # 1.3 | <notextile></notextile>
-Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-lang3 # 3.8 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-lang3 # 3.9 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.commons # commons-text # 1.7 | <notextile></notextile>
 Apache | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | org.apache.httpcomponents # httpclient # 4.5.13 | <notextile></notextile>
@@ -134,7 +132,7 @@ Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typ
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # play-test_2.12 # 2.8.19 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # play_2.12 # 2.8.19 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.html) | com.typesafe.play # twirl-api_2.12 # 1.5.1 | <notextile></notextile>
-Apache | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-codec # commons-codec # 1.16.0 | <notextile></notextile>
+Apache | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) | commons-codec # commons-codec # 1.17.0 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) | io.delta # delta-core_2.12 # 2.1.0 | <notextile></notextile>
 Apache | [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) | io.delta # delta-storage # 2.1.0 | <notextile></notextile>
 Apache | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | org.scala-lang # scala-compiler # 2.12.13 | <notextile></notextile>
@@ -240,25 +238,6 @@ BSD | [New BSD License](http://www.opensource.org/licenses/bsd-license.php) | or
 BSD | [The BSD License](http://www.antlr.org/license.html) | org.antlr # antlr4-runtime # 4.8 | <notextile></notextile>
 BSD | [Two-clause BSD-style license](http://github.com/sbt/junit-interface/blob/master/LICENSE.txt) | com.novocode # junit-interface # 0.11 | <notextile></notextile>
 CC0 | [CC0](http://creativecommons.org/publicdomain/zero/1.0/) | org.reactivestreams # reactive-streams # 1.0.3 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-collections # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-common # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-concurrent # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-configuration # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-csv # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-diagnostics # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-graphdb-api # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-index # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-io # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-kernel # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-kernel-api # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-logging # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-lucene-upgrade # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-procedure-api # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-resource # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-spatial-index # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-ssl # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-unsafe # 3.5.2 | <notextile></notextile>
-GPL | [GNU General Public License, Version 3](http://www.gnu.org/licenses/gpl-3.0-standalone.html) | org.neo4j # neo4j-values # 3.5.2 | <notextile></notextile>
 GPL | [GPL2 w/ CPE](https://www.gnu.org/software/classpath/license.html) | jakarta.transaction # jakarta.transaction-api # 1.3.3 | <notextile></notextile>
 GPL | [GPL2 w/ CPE](https://www.gnu.org/software/classpath/license.html) | jakarta.ws.rs # jakarta.ws.rs-api # 2.1.6 | <notextile></notextile>
 GPL with Classpath Extension | [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE) | javax.annotation # javax.annotation-api # 1.3.2 | <notextile></notextile>
@@ -288,12 +267,9 @@ MIT | [The MIT License(MIT)](http://opensource.org/licenses/MIT) | net.sf.geogra
 Mozilla | [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt) | net.sourceforge.htmlunit # htmlunit-core-js # 2.36.0 | <notextile></notextile>
 Public Domain | [Public Domain](null) | aopalliance # aopalliance # 1.0 | <notextile></notextile>
 Public Domain | [Public domain](null) | net.iharder # base64 # 2.3.8 | <notextile></notextile>
-unrecognized | [Bouncy Castle Licence](http://www.bouncycastle.org/licence.html) | org.bouncycastle # bcpkix-jdk15on # 1.60 | <notextile></notextile>
-unrecognized | [Bouncy Castle Licence](http://www.bouncycastle.org/licence.html) | org.bouncycastle # bcprov-jdk15on # 1.60 | <notextile></notextile>
+unrecognized | [Bouncy Castle Licence](http://www.bouncycastle.org/licence.html) | org.bouncycastle # bcprov-jdk15on # 1.52 | <notextile></notextile>
 unrecognized | [EDL 1.0](http://www.eclipse.org/org/documents/edl-v10.php) | jakarta.activation # jakarta.activation-api # 1.2.2 | <notextile></notextile>
 unrecognized | [Eclipse Distribution License - v 1.0](http://www.eclipse.org/org/documents/edl-v10.php) | jakarta.xml.bind # jakarta.xml.bind-api # 2.3.3 | <notextile></notextile>
-unrecognized | [Eclipse Public License - v 1.0](https://www.eclipse.org/legal/epl-v10.html) | org.eclipse.collections # eclipse-collections # 9.2.0 | <notextile></notextile>
-unrecognized | [Eclipse Public License - v 1.0](https://www.eclipse.org/legal/epl-v10.html) | org.eclipse.collections # eclipse-collections-api # 9.2.0 | <notextile></notextile>
 unrecognized | [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | junit # junit # 4.13.2 | <notextile></notextile>
 unrecognized | [Eclipse Publish License, Version 1.0](https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt) | org.locationtech.jts # jts # 1.16.0 | <notextile></notextile>
 unrecognized | [Eclipse Publish License, Version 1.0](https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt) | org.locationtech.jts # jts-core # 1.16.0 | <notextile></notextile>

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,5 @@
 /archive
+/lynxkite.jar
+/lynxkite-env.yml
+/python_requirements.txt
+/python_requirements_cuda.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,24 +1,24 @@
 # Single-machine LynxKite image.
-FROM mambaorg/micromamba:0.25.1
+# Set --build-arg KITE_ENABLE_CUDA=yes to add CUDA dependencies.
+ARG KITE_ENABLE_CUDA=no
+FROM mambaorg/micromamba:1.5.8-jammy as cuda-no
+FROM mambaorg/micromamba:1.5.8-jammy-cuda-12.4.1 as cuda-yes
+FROM cuda-$KITE_ENABLE_CUDA
+USER root
 
 # Install dependencies early so they are in a low layer.
 COPY lynxkite-env.yml /
 RUN micromamba install -y -n base -f /lynxkite-env.yml && \
     micromamba clean --all --yes
+COPY python_requirements.txt /
+RUN /opt/conda/bin/pip install -r /python_requirements.txt
 
-USER root
-# Set --build-arg KITE_ENABLE_CUDA=yes to add CUDA dependencies too.
+# CUDA dependencies.
 ARG KITE_ENABLE_CUDA=no
 ENV KITE_ENABLE_CUDA=$KITE_ENABLE_CUDA
-# The user has to configure these.
-ENV KITE_MASTER_MEMORY_MB 1024
-ENV SPHYNX_CACHED_ENTITIES_MAX_MEM_MB 1024
-VOLUME /data
-VOLUME /metadata
-
-# Add a dependency missed by Conda. (https://github.com/rapidsai/ucx-py/issues/790)
+COPY python_requirements_cuda.txt /
 RUN if [ $KITE_ENABLE_CUDA = yes ]; then \
-  apt-get update && apt-get install -y libnuma-dev && rm -rf /var/lib/apt/lists/*; fi
+    /opt/conda/bin/pip install -r /python_requirements_cuda.txt; fi
 
 # Install LynxKite.
 COPY lynxkite.jar /
@@ -29,6 +29,12 @@ COPY run.sh /
 RUN rm /opt/conda/lib/libtinfo.so.6
 ENV LD_LIBRARY_PATH /opt/conda/lib
 ENV ADD_TO_PYTHON_JAIL /opt/conda/lib
+
+# The user has to configure these.
+ENV KITE_MASTER_MEMORY_MB 1024
+ENV SPHYNX_CACHED_ENTITIES_MAX_MEM_MB 1024
+VOLUME /data
+VOLUME /metadata
 
 CMD ["/run.sh"]
 

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,0 +1,12 @@
+# Python dependencies with the exception of big CUDA libraries.
+autopep8
+matplotlib
+mypy
+numpy
+openai>=1
+pandas>=2
+pyarrow
+requests
+ruamel.yaml
+typed-ast
+types-requests

--- a/python_requirements_cuda.txt
+++ b/python_requirements_cuda.txt
@@ -1,0 +1,15 @@
+# Python dependencies for CUDA operations. They are separated because they are big.
+--extra-index-url https://pypi.nvidia.com
+angle-emb
+cugraph-cu12
+scikit-learn
+sentence-transformers
+torch_geometric==2.2.*
+torch==2.3.*
+transformers
+--find-links https://data.pyg.org/whl/torch-2.3.0+cu121.html
+pyg_lib
+torch_scatter
+torch_sparse
+torch_cluster
+torch_spline_conv

--- a/python_requirements_testing.txt
+++ b/python_requirements_testing.txt
@@ -1,0 +1,5 @@
+# Python dependencies for CI. These are slower but lighter than the normal dependencies.
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch_geometric==2.2.*
+torch==2.3.*
+torch-cluster

--- a/release.sh
+++ b/release.sh
@@ -9,12 +9,14 @@ cp target/scala-2.12/lynxkite-$VERSION.jar docker/archive/
 cd docker
 cp archive/lynxkite-$VERSION.jar lynxkite.jar
 ../conda-env.sh > lynxkite-env.yml
+cp ../python_requirements* .
 docker build . -t lynxkite/lynxkite:latest
 docker build . -t lynxkite/lynxkite:$VERSION
-../conda-env.sh cuda > lynxkite-env.yml
 docker build . --build-arg KITE_ENABLE_CUDA=yes -t lynxkite/lynxkite:latest-cuda
 docker build . --build-arg KITE_ENABLE_CUDA=yes -t lynxkite/lynxkite:$VERSION-cuda
-docker push lynxkite/lynxkite:$VERSION
-docker push lynxkite/lynxkite:$VERSION-cuda
-docker push lynxkite/lynxkite:latest
-docker push lynxkite/lynxkite:latest-cuda
+if [ "$2" == "push" ]; then
+  docker push lynxkite/lynxkite:$VERSION
+  docker push lynxkite/lynxkite:$VERSION-cuda
+  docker push lynxkite/lynxkite:latest
+  docker push lynxkite/lynxkite:latest-cuda
+fi


### PR DESCRIPTION
Because of the old Java and Spark dependencies (blocked by #265 and #413) Conda refuses to install some new dependencies, like OpenAI 1.x. So I switched to using `pip` for Python dependencies. I don't know if it's `pip`'s fault, but when building the Docker images for 5.4.0 I was surprised to see they are >20GB. To fix that I split `python_requirements.txt` into two. (A bit differently than the CUDA/non-CUDA split was with Conda.)

Now we can build a ~2GB Docker image. But I guess it's better to call this 5.4.1 now.